### PR TITLE
PET-150 Feat: 공통 예외 처리 클래스 생성

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/exception/ApplicationException.java
+++ b/src/main/java/org/retriever/server/dailypet/exception/ApplicationException.java
@@ -1,0 +1,18 @@
+package org.retriever.server.dailypet.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+
+    public ApplicationException(String errorCode, String message, HttpStatus httpStatus) {
+        super(message);
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/exception/GlobalExceptionControllerAdvice.java
+++ b/src/main/java/org/retriever/server/dailypet/exception/GlobalExceptionControllerAdvice.java
@@ -1,0 +1,19 @@
+package org.retriever.server.dailypet.exception;
+
+import org.retriever.server.dailypet.exception.dto.ApiErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionControllerAdvice {
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ApiErrorResponse> applicationException(ApplicationException exception) {
+        String errorCode = exception.getErrorCode();
+
+        return ResponseEntity
+                .status(exception.getHttpStatus())
+                .body(new ApiErrorResponse(errorCode));
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/exception/dto/ApiErrorResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/exception/dto/ApiErrorResponse.java
@@ -1,0 +1,16 @@
+package org.retriever.server.dailypet.exception.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ApiErrorResponse {
+
+    private String errorCode;
+
+    public ApiErrorResponse(String errorCode) {
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-150
- **관련 문서** : 추후 작성 예정

## Changes 

- ApplicationException : RuntimeException을 상속 받은 BusinessException
- GlobalExceptionControllerAdvice : 발생하는 예외를 공통으로 처리할 수 있는 RestControllerAdvice
- ApiErrorResponse : 예외 응답을 표준화

## Test Checklist

- [ ] 

## To Client

- 런타임 시점에서 발생할 수 있는 예외들을 처리하기 위한 기본 클래스 템플릿입니다.
- 에러 시 클라이언트가 필요한 필드는 ApiErrorResponse에 추가하면 모든 응답에 공통으로 적용됩니다.
