### PR TITLE
PET-211 Test: 회원 entity, controller, service 단위 테스트 작성

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/DailypetApplication.java
+++ b/src/main/java/org/retriever/server/dailypet/DailypetApplication.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
-@EnableJpaAuditing
 public class DailypetApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
@@ -1,7 +1,7 @@
 package org.retriever.server.dailypet.domain.member.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
-import org.hibernate.validator.constraints.URL;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
 
 import javax.validation.constraints.Email;
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
 @Getter
+@Builder
 public class SignUpRequest {
 
     @NotEmpty

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SnsLoginRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SnsLoginRequest.java
@@ -1,5 +1,6 @@
 package org.retriever.server.dailypet.domain.member.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Email;
@@ -7,6 +8,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
 @Getter
+@Builder
 public class SnsLoginRequest {
 
     @NotEmpty

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/ValidateMemberNicknameRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/ValidateMemberNicknameRequest.java
@@ -1,11 +1,13 @@
 package org.retriever.server.dailypet.domain.member.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
 @Getter
+@Builder
 public class ValidateMemberNicknameRequest {
 
     @NotEmpty

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/ValidateMemberNicknameRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/ValidateMemberNicknameRequest.java
@@ -1,13 +1,14 @@
 package org.retriever.server.dailypet.domain.member.dto.request;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class ValidateMemberNicknameRequest {
 
     @NotEmpty

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/SnsLoginResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/SnsLoginResponse.java
@@ -1,14 +1,12 @@
 package org.retriever.server.dailypet.domain.member.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
+@Getter
 public class SnsLoginResponse {
 
     @Schema(description = "유저 SNS 프로필 이름")

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package org.retriever.server.dailypet.domain.member.entity;
 
 import lombok.*;
+import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
@@ -64,13 +65,13 @@ public class Member extends BaseTimeEntity {
         this.deviceToken = deviceToken;
     }
 
-    public static Member createNewMember(String email, String nickName, String profileImageUrl, ProviderType type, String deviceToken) {
+    public static Member createNewMember(SignUpRequest signUpRequest) {
         return Member.builder()
-                .email(email)
-                .nickName(nickName)
-                .profileImageUrl(profileImageUrl)
-                .type(type)
-                .deviceToken(deviceToken)
+                .email(signUpRequest.getEmail())
+                .nickName(signUpRequest.getSnsNickName())
+                .profileImageUrl(signUpRequest.getProfileImageUrl())
+                .type(signUpRequest.getProviderType())
+                .deviceToken(signUpRequest.getDeviceToken())
                 .build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/exception/DuplicateMemberException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/exception/DuplicateMemberException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateMemberException extends MemberException{
+
+    private static final String ERROR_CODE = "MEMBER-003";
+    private static final String MESSAGE = "이미 등록된 회원입니다.";
+    private static final HttpStatus STATUS = HttpStatus.CONFLICT;
+
+    public DuplicateMemberException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -47,13 +47,7 @@ public class MemberService {
             throw new DuplicateMemberException();
         }
 
-        Member signUpMember = Member.createNewMember(
-                dto.getEmail(),
-                dto.getSnsNickName(),
-                dto.getProfileImageUrl(),
-                dto.getProviderType(),
-                dto.getDeviceToken()
-        );
+        Member signUpMember = Member.createNewMember(dto);
 
         memberRepository.save(signUpMember);
 

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberException;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberNicknameException;
 import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundException;
@@ -42,11 +43,17 @@ public class MemberService {
 
     @Transactional
     public SignUpResponse signUpAndRegisterProfile(SignUpRequest dto) {
-        Member signUpMember = Member.createNewMember(dto.getEmail(),
+        if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
+            throw new DuplicateMemberException();
+        }
+
+        Member signUpMember = Member.createNewMember(
+                dto.getEmail(),
                 dto.getSnsNickName(),
                 dto.getProfileImageUrl(),
                 dto.getProviderType(),
-                dto.getDeviceToken());
+                dto.getDeviceToken()
+        );
 
         memberRepository.save(signUpMember);
 

--- a/src/main/java/org/retriever/server/dailypet/global/config/JpaAuditingConfig.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.retriever.server.dailypet.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/org/retriever/server/dailypet/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .authorizeRequests()
                     .antMatchers(HttpMethod.POST, "/api/v1/auth/login",
                             "/api/v1/validation/nickname", "/api/v1/auth/sign-up").permitAll()
-                    .antMatchers(HttpMethod.GET, "/api/v1/auth/test").permitAll()
+                    .antMatchers(HttpMethod.GET, "/api/v1/test").permitAll()
                     .anyRequest().authenticated();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/common/config/SecurityTestConfig.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/config/SecurityTestConfig.java
@@ -1,0 +1,20 @@
+package org.retriever.server.dailypet.domain.common.config;
+
+import org.retriever.server.dailypet.global.config.jwt.JwtAccessDeniedHandler;
+import org.retriever.server.dailypet.global.config.jwt.JwtAuthenticationEntryPoint;
+import org.retriever.server.dailypet.global.config.jwt.JwtTokenProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@TestConfiguration
+public class SecurityTestConfig {
+
+    @MockBean
+    protected JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    protected JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockBean
+    protected JwtAccessDeniedHandler jwtAccessDeniedHandler;
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -1,4 +1,4 @@
-package org.retriever.server.dailypet.domain.factory;
+package org.retriever.server.dailypet.domain.common.factory;
 
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -3,6 +3,7 @@ package org.retriever.server.dailypet.domain.common.factory;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
+import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
 
@@ -25,6 +26,14 @@ public class MemberFactory {
         return SnsLoginRequest.builder()
                 .snsNickName("test")
                 .email("test@naver.com")
+                .build();
+    }
+
+    public static SnsLoginResponse createSnsLoginResponse() {
+        return SnsLoginResponse.builder()
+                .snsNickName("test")
+                .email("test@naver.com")
+                .jwtToken("testToken")
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/factory/MemberFactory.java
@@ -1,0 +1,51 @@
+package org.retriever.server.dailypet.domain.factory;
+
+import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
+import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
+import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.ProviderType;
+
+public class MemberFactory {
+
+    private MemberFactory() {
+    }
+
+    public static Member createTestMember() {
+        return Member.builder()
+                .email("test@naver.com")
+                .nickName("test")
+                .profileImageUrl("abcdefghijk")
+                .type(ProviderType.KAKAO)
+                .deviceToken("abcdefg12345")
+                .build();
+    }
+
+    public static SnsLoginRequest createSnsLoginRequest() {
+        return SnsLoginRequest.builder()
+                .snsNickName("test")
+                .email("test@naver.com")
+                .build();
+    }
+
+    public static String createToken(String token) {
+        return token;
+    }
+
+    public static ValidateMemberNicknameRequest createValidateNicknameRequest(String nickname) {
+        return ValidateMemberNicknameRequest.builder()
+                .nickName(nickname)
+                .build();
+    }
+
+    public static SignUpRequest createSignUpRequest() {
+        return SignUpRequest.builder()
+                .email("test@naver.com")
+                .snsNickName("test")
+                .deviceToken("abcde12345")
+                .profileImageUrl("S3URL")
+                .providerType(ProviderType.KAKAO)
+                .build();
+    }
+
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,121 @@
+package org.retriever.server.dailypet.domain.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.retriever.server.dailypet.domain.common.config.SecurityTestConfig;
+import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
+import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
+import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
+import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
+import org.retriever.server.dailypet.domain.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("MemberController 테스트")
+@WebMvcTest(controllers = MemberController.class)
+@Import(SecurityTestConfig.class)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    MemberService memberService;
+
+    @MockBean
+    MemberRepository memberRepository;
+
+    @DisplayName("로그인 시도 시 회원 확인 후 정상 로그인")
+    @Test
+    void checkMemberAndLogin() throws Exception {
+
+        // given
+        SnsLoginRequest snsLoginRequest = MemberFactory.createSnsLoginRequest();
+        SnsLoginResponse snsLoginResponse = MemberFactory.createSnsLoginResponse();
+        given(memberService.checkMemberAndLogin(any()))
+                .willReturn(snsLoginResponse);
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(snsLoginRequest))
+                .characterEncoding("UTF-8"));
+
+        // then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("email").value(snsLoginRequest.getEmail()))
+                .andExpect(jsonPath("snsNickName").value(snsLoginRequest.getSnsNickName()))
+                .andExpect(jsonPath("jwtToken").value("testToken"))
+                .andDo(print())
+                .andReturn()
+                .getResponse();
+    }
+
+    @DisplayName("닉네임 검증에 성공하는 요청")
+    @Test
+    void validateMemberNickName() throws Exception {
+
+        // given
+        ValidateMemberNicknameRequest validateNicknameRequest =
+                MemberFactory.createValidateNicknameRequest("test");
+        when(memberRepository.findByNickName(any())).thenReturn(Optional.empty());
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/validation/nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(validateNicknameRequest))
+                .characterEncoding("UTF-8"));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse();
+    }
+
+    @Test
+    void signUpAndRegisterProfile() {
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void testController() throws Exception {
+
+        // given
+
+        // when
+        final ResultActions actions = mockMvc.perform(get("/api/v1/test")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8"));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(content().string(containsString("hello it's test")));
+
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -1,0 +1,41 @@
+package org.retriever.server.dailypet.domain.member.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.retriever.server.dailypet.domain.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
+import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
+import org.retriever.server.dailypet.domain.member.enums.RoleType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @DisplayName("회원가입 request dto를 받아서 새로운 유저 생성")
+    @Test
+    void createNewMember() {
+
+        // given
+        SignUpRequest signUpRequest = MemberFactory.createSignUpRequest();
+
+        // when
+        Member newMember = Member.createNewMember(signUpRequest);
+
+        // then
+        assertThat(newMember.getId()).isNull();
+        assertThat(newMember.getNickName()).isEqualTo(signUpRequest.getSnsNickName());
+        assertThat(newMember.getEmail()).isEqualTo(signUpRequest.getEmail());
+        assertThat(newMember.getProfileImageUrl()).isEqualTo(signUpRequest.getProfileImageUrl());
+        assertThat(newMember.getProviderType()).isEqualTo(signUpRequest.getProviderType());
+        assertThat(newMember.getDeviceToken()).isEqualTo(signUpRequest.getDeviceToken());
+
+        assertThat(newMember.getAccountStatus()).isEqualTo(AccountStatus.ACTIVE);
+        assertThat(newMember.getRoleType()).isEqualTo(RoleType.MEMBER);
+        assertThat(newMember.getIsPersonalInformationAgree()).isTrue();
+        assertThat(newMember.getIsToSAgree()).isTrue();
+        assertThat(newMember.getIsPushAgree()).isFalse();
+
+        assertThat(newMember.getFamilyRoleName()).isEqualTo("별명을 입력해주세요!");
+        assertThat(newMember.getPassword()).isNull();
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -2,7 +2,7 @@ package org.retriever.server.dailypet.domain.member.entity;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.retriever.server.dailypet.domain.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.retriever.server.dailypet.domain.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,160 @@
+package org.retriever.server.dailypet.domain.member.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
+import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
+import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
+import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
+import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.ProviderType;
+import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberException;
+import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberNicknameException;
+import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundException;
+import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
+import org.retriever.server.dailypet.global.config.jwt.JwtTokenProvider;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    MemberService memberService;
+
+    @DisplayName("로그인 - 가입된 회원인 경우 JWT 토큰을 반환해준다.")
+    @Test
+    void check_member_success_and_login() {
+
+        // given
+        SnsLoginRequest snsLoginRequest = createSnsLoginRequest();
+        Member member = createTestMember();
+        String testToken = "jwtToken";
+        when(memberRepository.findByEmail(any())).thenReturn(Optional.of(member));
+        when(jwtTokenProvider.createToken(any())).thenReturn(createToken(testToken));
+
+        // when
+        SnsLoginResponse snsLoginResponse = memberService.checkMemberAndLogin(createSnsLoginRequest());
+
+        // then
+        assertAll(
+                () -> assertEquals(snsLoginResponse.getEmail(), member.getEmail()),
+                () -> assertEquals(snsLoginResponse.getSnsNickName(), member.getNickName()),
+                () -> assertEquals(snsLoginResponse.getJwtToken(), testToken)
+        );
+    }
+
+    @DisplayName("로그인 - 가입되지 않은 회원인 경우 MemberNotFoundException 예외 발생")
+    @Test
+    void check_member_fail_and_throw_exception() {
+
+        // given request 만들고
+        SnsLoginRequest snsLoginRequest = createSnsLoginRequest();
+        when(memberRepository.findByEmail(any())).thenReturn(Optional.empty());
+
+        // when, then
+        assertThrows(MemberNotFoundException.class,
+                () -> memberService.checkMemberAndLogin(createSnsLoginRequest()));
+    }
+
+    @DisplayName("닉네임 검증 - 프로필 등록에서 닉네임 검증 실패 시 DuplicateMemberNicknameException 예외 발생")
+    @Test
+    void validate_nickname_fail_and_throw_exception() {
+
+        // given
+        Member member = createTestMember();
+        ValidateMemberNicknameRequest nicknameRequest = createValidateNicknameRequest(member.getNickName());
+        when(memberRepository.findByNickName(any())).thenReturn(Optional.of(member));
+
+        // when, then
+        assertThrows(DuplicateMemberNicknameException.class,
+                () -> memberService.validateMemberNickName(nicknameRequest));
+    }
+
+    @DisplayName("회원 가입 - 정상 회원 가입 후 프로필 등록")
+    @Test
+    void sign_up_success_and_register_profile() {
+
+        // given
+        Member member = createTestMember();
+        SignUpRequest signUpRequest = createSignUpRequest();
+        String testToken = "jwtToken";
+        when(memberRepository.findByEmail(signUpRequest.getEmail())).thenReturn(Optional.empty());
+        when(memberRepository.save(any())).thenReturn(member);
+        when(jwtTokenProvider.createToken(any())).thenReturn(testToken);
+
+        // when
+        SignUpResponse signUpResponse = memberService.signUpAndRegisterProfile(signUpRequest);
+
+        // then
+        assertAll(
+                () -> assertEquals(signUpResponse.getJwtToken(), testToken),
+                () -> verify(memberRepository, times(1)).save(any()),
+                () -> verify(jwtTokenProvider, times(1)).createToken(any())
+        );
+    }
+
+    @DisplayName("회원 가입 - 가입 시 중복된 이메일이 존재할 경우 DuplicateMemberException 예외 발생")
+    @Test
+    void sign_up_fail_and_throw_exception() {
+
+        // given
+        Member member = createTestMember();
+        SignUpRequest signUpRequest = createSignUpRequest();
+        when(memberRepository.findByEmail(signUpRequest.getEmail())).thenReturn(Optional.of(member));
+
+        // when, then
+        assertThrows(DuplicateMemberException.class, () -> memberService.signUpAndRegisterProfile(signUpRequest));
+    }
+
+    private Member createTestMember() {
+        return Member.builder()
+                .email("test@naver.com")
+                .nickName("test")
+                .profileImageUrl("abcdefghijk")
+                .type(ProviderType.KAKAO)
+                .deviceToken("abcdefg12345")
+                .build();
+    }
+
+    private SnsLoginRequest createSnsLoginRequest() {
+        return SnsLoginRequest.builder()
+                .snsNickName("test")
+                .email("test@naver.com")
+                .build();
+    }
+
+    private String createToken(String token) {
+        return token;
+    }
+
+    private ValidateMemberNicknameRequest createValidateNicknameRequest(String nickname) {
+        return ValidateMemberNicknameRequest.builder()
+                .nickName(nickname)
+                .build();
+    }
+
+    private SignUpRequest createSignUpRequest() {
+        return SignUpRequest.builder()
+                .email("test@naver.com")
+                .snsNickName("test")
+                .deviceToken("abcde12345")
+                .profileImageUrl("S3URL")
+                .providerType(ProviderType.KAKAO)
+                .build();
+    }
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-211
- **관련 문서** : N/A

## Changes 

- 회원 entity 단위 테스트 작성
- 회원 Controller 단위 테스트 작성
- 회원 Service 단위 테스트 작성
- security bean을 위한 TestConfiguration bean 추가
- 테스트 전용 MemberFactory 생성 : 테스트 용 정적 메서드
- builder 추가한 dto들이 직렬화되지 않는 오류 수정 : 기본 생성자, 전체 생성자 추가

## Test Checklist

- [ ] todo

## To Client

- 원래 rest docs를 위해서 테스트 작성을 했는데, 현재 일단 swagger 사용하니까 rest docs 문서화 작업은 안했습니다.