### PR TITLE
PET-121 가족 내 닉네임 중복 검증 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -7,14 +7,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -34,6 +38,20 @@ public class FamilyController {
     @PostMapping("/validation/family-name")
     public ResponseEntity<Void> validateFamilyName(@RequestBody @Valid ValidateFamilyNameRequest dto) {
         familyService.validateFamilyName(dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "가족 내 닉네임 검증", description = "가족 내 구성원들끼리 닉네임 중복 여부를 검증")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용 가능한 가족 이름"),
+            @ApiResponse(responseCode = "409", description = "사용 중인 중복 가족 이름"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/validation/family-role-name")
+    public ResponseEntity<Void> validateFamilyRoleName(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                       @RequestBody @Valid ValidateFamilyRoleNameRequest dto) {
+        familyService.validateFamilyRoleName(userDetails, dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/ValidateFamilyRoleNameRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/ValidateFamilyRoleNameRequest.java
@@ -1,0 +1,12 @@
+package org.retriever.server.dailypet.domain.family.dto.request;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ValidateFamilyRoleNameRequest {
+
+    private String familyRoleName;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/exception/DuplicateFamilyRoleNameException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/exception/DuplicateFamilyRoleNameException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.family.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateFamilyRoleNameException extends FamilyException {
+
+    private static final String ERROR_CODE = "FAMILY-002";
+    private static final String MESSAGE = "가족 내 중복된 이름이 존재합니다.";
+    private static final HttpStatus STATUS = HttpStatus.CONFLICT;
+
+    public DuplicateFamilyRoleNameException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyMemberRepository.java
@@ -1,0 +1,8 @@
+package org.retriever.server.dailypet.domain.family.repository;
+
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long> {
+
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -2,19 +2,43 @@ package org.retriever.server.dailypet.domain.family.service;
 
 import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
+import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyRoleNameException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyMemberRepository;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundException;
+import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class FamilyService {
 
     private final FamilyRepository familyRepository;
+    private final MemberRepository memberRepository;
+    private final FamilyMemberRepository familyMemberRepository;
 
     public void validateFamilyName(ValidateFamilyNameRequest dto) {
         if (familyRepository.findByFamilyName(dto.getFamilyName()).isPresent()) {
             throw new DuplicateFamilyNameException();
+        }
+    }
+
+    // TODO : 쿼리 직접 만들어서 한 번에 해당 가족에 속한 member 참조하기 (현재는 familyMember.getMember()로 가져옴)
+    public void validateFamilyRoleName(CustomUserDetails userDetails, ValidateFamilyRoleNameRequest dto) {
+        Member member = memberRepository.findById(userDetails.getId())
+                .orElseThrow(MemberNotFoundException::new);
+        List<FamilyMember> familyMemberList = member.getFamilyMemberList();
+
+        if (familyMemberList.stream()
+                .anyMatch(x -> x.getMember().getFamilyRoleName().equals(dto.getFamilyRoleName()))) {
+            throw new DuplicateFamilyRoleNameException();
         }
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/config/security/CustomUserDetails.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/security/CustomUserDetails.java
@@ -16,6 +16,10 @@ public class CustomUserDetails implements UserDetails {
         this.member = member;
     }
 
+    public Long getId() {
+        return member.getId();
+    }
+
     @Override
     public String getPassword() {
         return member.getPassword();


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-121
- **관련 문서** : N/A

## Changes 

- 가족 내 닉네임 중복 검증 API
- FamilyMemberRepository 생성
- AuthenticationPrincipal 어노테이션을 이용해서 현재 쓰레드의 SpringContextHolder에 저장된 Principal 조회

## Test Checklist

- [ ] 내가 속한 가족 멤버 조회를 쿼리 이용해서 한 번에 조회하기
- [ ] Util 클래스의 메서드로 AuthenticationPrincipal 어노테이션 대신 현재 쓰레드로컬의 getContext 조회하기

## To Client

- None
