### PR TITLE
PET-122 가족 생성 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
 import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
@@ -64,9 +65,8 @@ public class FamilyController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/family")
-    public ResponseEntity<Void> createFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                       @RequestBody @Valid CreateFamilyRequest dto) {
-        familyService.createFamily(userDetails, dto);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<CreateFamilyResponse> createFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                             @RequestBody @Valid CreateFamilyRequest dto) {
+        return ResponseEntity.ok(familyService.createFamily(userDetails, dto));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
@@ -52,6 +53,20 @@ public class FamilyController {
     public ResponseEntity<Void> validateFamilyRoleName(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                        @RequestBody @Valid ValidateFamilyRoleNameRequest dto) {
         familyService.validateFamilyRoleName(userDetails, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "가족 생성", description = "새로운 가족을 생성하고 해당 멤버는 가족 리더가 된다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "가족 생성"),
+            @ApiResponse(responseCode = "400", description = "가족 생성 오류"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/family")
+    public ResponseEntity<Void> createFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                       @RequestBody @Valid CreateFamilyRequest dto) {
+        familyService.createFamily(userDetails, dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/CreateFamilyRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/CreateFamilyRequest.java
@@ -1,0 +1,16 @@
+package org.retriever.server.dailypet.domain.family.dto.request;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class CreateFamilyRequest {
+
+    private String familyName;
+
+    private String familyRoleName;
+
+    private String profileImageUrl;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/CreateFamilyResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/CreateFamilyResponse.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.family.dto.response;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class CreateFamilyResponse {
+
+    private String familyName;
+
+    private String invitationCode;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
@@ -1,9 +1,7 @@
 package org.retriever.server.dailypet.domain.family.entity;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 
@@ -15,10 +13,11 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class Family extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long familyId;
 
     @Enumerated(EnumType.STRING)
@@ -27,10 +26,25 @@ public class Family extends BaseTimeEntity {
     @Column(nullable = false, unique = true, length = 50)
     private String familyName;
 
+    @Column(nullable = false, unique = true, length = 10)
     private String invitationCode;
 
     private String profileImageUrl;
 
-    @OneToMany(mappedBy = "family")
+    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL)
     private List<FamilyMember> familyMemberList = new ArrayList<>();
+
+    public static Family createFamily(CreateFamilyRequest dto, String invitationCode) {
+        return Family.builder()
+                .familyName(dto.getFamilyName())
+                .familyStatus(FamilyStatus.ACTIVE)
+                .invitationCode(invitationCode)
+                .profileImageUrl(dto.getProfileImageUrl())
+                .familyMemberList(new ArrayList<>())
+                .build();
+    }
+
+    public void insertNewMember(FamilyMember familyMember) {
+        familyMemberList.add(familyMember);
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/FamilyMember.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/FamilyMember.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 public class FamilyMember extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long familyMemberId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/FamilyMember.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/FamilyMember.java
@@ -25,7 +25,7 @@ public class FamilyMember extends BaseTimeEntity {
     @JoinColumn(name = "familyId", nullable = false)
     private Family family;
 
-    public static FamilyMember of(Member member, Family family) {
+    public static FamilyMember createFamilyMember(Member member, Family family) {
         return FamilyMember.builder()
                 .member(member)
                 .family(family)

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
@@ -48,7 +49,7 @@ public class FamilyService {
     }
 
     @Transactional
-    public void createFamily(CustomUserDetails userDetails, CreateFamilyRequest dto) {
+    public CreateFamilyResponse createFamily(CustomUserDetails userDetails, CreateFamilyRequest dto) {
 
         // 멤버 조회 및 권한 지정
         Member member = memberRepository.findById(userDetails.getId())
@@ -63,5 +64,10 @@ public class FamilyService {
         // 연관관계 편의 메서드 - family.familyMemberList에 add & cascade.All 옵션을 통해 familyMember 자동 persist
         newFamily.insertNewMember(familyMember);
         familyRepository.save(newFamily);
+
+        return CreateFamilyResponse.builder()
+                .familyName(newFamily.getFamilyName())
+                .invitationCode(invitationCode)
+                .build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -79,4 +79,8 @@ public class Member extends BaseTimeEntity {
                 .deviceToken(signUpRequest.getDeviceToken())
                 .build();
     }
+
+    public void setFamilyLeader() {
+        this.roleType = RoleType.FAMILY_LEADER;
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/utils/invitationcode/InvitationCodeUtil.java
+++ b/src/main/java/org/retriever/server/dailypet/global/utils/invitationcode/InvitationCodeUtil.java
@@ -1,0 +1,31 @@
+package org.retriever.server.dailypet.global.utils.invitationcode;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Component
+@Slf4j
+public class InvitationCodeUtil {
+
+    private static final int INVITATION_CODE_DIGIT = 10;
+
+    private InvitationCodeUtil() {
+
+    }
+
+    public static String createInvitationCode() {
+        String uuid = UUID.randomUUID().toString();
+        String shortUUID = parseToShortUUID(uuid);
+        log.info("가족 생성 : 초대코드 생성 = {}", shortUUID);
+        return shortUUID;
+    }
+
+    private static String parseToShortUUID(String uuid) {
+        int anInt = ByteBuffer.wrap(uuid.getBytes(StandardCharsets.UTF_8)).getInt();
+        return Integer.toString(anInt, INVITATION_CODE_DIGIT);
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -13,7 +13,7 @@ class MemberTest {
 
     @DisplayName("회원가입 request dto를 받아서 새로운 유저 생성")
     @Test
-    void createNewMember() {
+    void create_new_member() {
 
         // given
         SignUpRequest signUpRequest = MemberFactory.createSignUpRequest();
@@ -37,5 +37,19 @@ class MemberTest {
 
         assertThat(newMember.getFamilyRoleName()).isEqualTo("별명을 입력해주세요!");
         assertThat(newMember.getPassword()).isNull();
+    }
+
+    @DisplayName("멤버 가족 리더 권한으로 변경")
+    @Test
+    void change_family_leader() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+
+        // when
+        testMember.setFamilyLeader();
+
+        // then
+        assertThat(testMember.getRoleType()).isEqualTo(RoleType.FAMILY_LEADER);
     }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-122
- **관련 문서** : N/A

## Changes 

- Member Entity에 권한 변경 메서드, 단위 테스트 추가
- 가족 초대 코드용 Util 클래스 생성
- 가족 생성 API 

## Test Checklist

- [ ] todo

## To Client

- 초대 코드는 숫자 10글자로 생성했습니다.
- 흐름은 가족 생성 요청-> 요청한 회원이 가족 리더가 되고, 새로운 가족을 생성, 해당 가족에 대한 초대 코드 생성 입니다.
- response field는 우선 가족 이름과 가족 초대 코드만 반환했습니다.
