### PR TITLE
PET-125 Feat: 가족 초대 코드 입력 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -10,14 +10,12 @@ import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyReque
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
+import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
 import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.security.Principal;
@@ -68,5 +66,17 @@ public class FamilyController {
     public ResponseEntity<CreateFamilyResponse> createFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                              @RequestBody @Valid CreateFamilyRequest dto) {
         return ResponseEntity.ok(familyService.createFamily(userDetails, dto));
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "가족 초대 코드 입력", description = "가족을 찾기 위해 초대 코드를 입력하고 가족 정보를 반환한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "가족 검색 성공"),
+            @ApiResponse(responseCode = "400", description = "초대 코드에 해당하는 가족이 없음"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/families/{invitationCode}")
+    public ResponseEntity<FindFamilyWithInvitationCodeResponse> findFamilyWithInvitationCode(@PathVariable String invitationCode) {
+        return ResponseEntity.ok(familyService.findFamilyWithInvitationCode(invitationCode));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/FindFamilyWithInvitationCodeResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/FindFamilyWithInvitationCodeResponse.java
@@ -1,0 +1,28 @@
+package org.retriever.server.dailypet.domain.family.dto.response;
+
+import lombok.*;
+import org.retriever.server.dailypet.domain.family.entity.Family;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FindFamilyWithInvitationCodeResponse {
+
+    private Long familyId;
+
+    private String familyName;
+
+    private int familyMemberCount;
+
+    private String profileImageUrl;
+
+    public static FindFamilyWithInvitationCodeResponse from(Family family) {
+        return FindFamilyWithInvitationCodeResponse.builder()
+                .familyId(family.getFamilyId())
+                .familyName(family.getFamilyName())
+                .familyMemberCount(family.getFamilyMemberList().size())
+                .profileImageUrl(family.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/exception/FamilyNotFoundException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/exception/FamilyNotFoundException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.family.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class FamilyNotFoundException extends FamilyException{
+
+    private static final String ERROR_CODE = "FAMILY-003";
+    private static final String MESSAGE = "해당하는 가족이 없습니다.";
+    private static final HttpStatus STATUS = HttpStatus.BAD_REQUEST;
+
+    public FamilyNotFoundException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface FamilyRepository extends JpaRepository<Family, Long> {
 
     Optional<Family> findByFamilyName(String familyName);
+
+    Optional<Family> findByInvitationCode(String invitationCode);
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -5,10 +5,12 @@ import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyReque
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
+import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyRoleNameException;
+import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
 import org.retriever.server.dailypet.domain.family.repository.FamilyMemberRepository;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
@@ -69,5 +71,11 @@ public class FamilyService {
                 .familyName(newFamily.getFamilyName())
                 .invitationCode(invitationCode)
                 .build();
+    }
+
+    public FindFamilyWithInvitationCodeResponse findFamilyWithInvitationCode(String code) {
+        Family family = familyRepository.findByInvitationCode(code).orElseThrow(FamilyNotFoundException::new);
+
+        return FindFamilyWithInvitationCodeResponse.from(family);
     }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-125
- **관련 문서** : N/A

## Changes 

- 가족 초대 코드 입력 API
- rest api의 method 의미에 따라서 Post -> Get으로 변경 (정보 조회)
- 기존에 body에 초대 코드를 전달하던 것을 pathVariable로 변경

## Test Checklist

- [ ] todo

## To Client

- mock API에 post로 등록되던 api를 get으로 변경했습니다. (사유 : method 의미에 따라 정보 조회는 get으로)
- 따라서 초대 코드는 api/v1/families/{invitationCode}로 전달하면 됩니다.
- 필드는 그대로 가족 id, 가족명, 가족 인원 수, 가족 이미지입니다.
