### PR TITLE
PET-126 가족 입장 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
@@ -18,7 +19,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.security.Principal;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -78,5 +78,20 @@ public class FamilyController {
     @GetMapping("/families/{invitationCode}")
     public ResponseEntity<FindFamilyWithInvitationCodeResponse> findFamilyWithInvitationCode(@PathVariable String invitationCode) {
         return ResponseEntity.ok(familyService.findFamilyWithInvitationCode(invitationCode));
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "가족 입장", description = "검증 완료된 가족 내 닉네임과 초대 코드를 통해 확인한 가족 그룹으로 입장한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "가족 입장 성공"),
+            @ApiResponse(responseCode = "400", description = "가족 입장 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/families/{familyId}")
+    public ResponseEntity<Void> enterFamily(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long familyId, @RequestBody @Valid EnterFamilyRequest dto) {
+        familyService.enterFamily(userDetails, familyId, dto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/EnterFamilyRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/EnterFamilyRequest.java
@@ -1,0 +1,12 @@
+package org.retriever.server.dailypet.domain.family.dto.request;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class EnterFamilyRequest {
+
+    private String familyRoleName;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -58,6 +58,7 @@ public class FamilyService {
         Member member = memberRepository.findById(userDetails.getId())
                 .orElseThrow(MemberNotFoundException::new);
         member.setFamilyLeader();
+        member.changeFamilyRoleName(dto.getFamilyRoleName());
 
         // 새로운 가족 그룹 생성 - 초대코드 생성
         String invitationCode = InvitationCodeUtil.createInvitationCode();

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.family.service;
 
 import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
+import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
@@ -77,5 +78,19 @@ public class FamilyService {
         Family family = familyRepository.findByInvitationCode(code).orElseThrow(FamilyNotFoundException::new);
 
         return FindFamilyWithInvitationCodeResponse.from(family);
+    }
+
+    @Transactional
+    public void enterFamily(CustomUserDetails userDetails, Long familyId, EnterFamilyRequest dto) {
+        Member member = memberRepository.findById(userDetails.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        Family family = familyRepository.findById(familyId).orElseThrow(FamilyNotFoundException::new);
+
+        member.changeFamilyRoleName(dto.getFamilyRoleName());
+
+        FamilyMember familyMember = FamilyMember.createFamilyMember(member, family);
+
+        family.insertNewMember(familyMember);
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -83,4 +83,8 @@ public class Member extends BaseTimeEntity {
     public void setFamilyLeader() {
         this.roleType = RoleType.FAMILY_LEADER;
     }
+
+    public void changeFamilyRoleName(String familyRoleName) {
+        this.familyRoleName = familyRoleName;
+    }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-126
- **관련 문서** : N/A

## Changes 

- 가족 입장 API
- 가족 생성 시 가족 리더의 가족 내 닉네임이 변경되지 않는 오류 수정

## Test Checklist

- [ ] todo

## To Client

- 가족 입장 시 검증 완료된 가족 내 닉네임과 들어갈 가족 id를 받아서 입장합니다.
- 입장 이후 메인 페이지가 띄워질텐데, 어떤 response field가 필요한지 의논 필요
