### PR TITLE
PET-214 반려동물 도메인 entity 세팅, 반려동물 이름 검증 API 

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -33,6 +34,9 @@ public class Family extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "family", cascade = CascadeType.ALL)
     private List<FamilyMember> familyMemberList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "family")
+    private List<Pet> petList = new ArrayList<>();
 
     public static Family createFamily(CreateFamilyRequest dto, String invitationCode) {
         return Family.builder()

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -1,0 +1,41 @@
+package org.retriever.server.dailypet.domain.pet.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
+import org.retriever.server.dailypet.domain.pet.service.PetService;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Pet API")
+public class PetController {
+
+    private final PetService petService;
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "가족 내 반려동물 이름 검증", description = "가족 내에서 반려동물의 닉네임 중복 여부를 검증")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용 가능한 반려 동물 이름"),
+            @ApiResponse(responseCode = "409", description = "가족 내에서 사용 중인 중복 반려 동물 이름"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/validation/families/{familyId}/pet-name")
+    public ResponseEntity<Void> validatePetNameInFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                        @RequestBody @Valid ValidatePetNameInFamilyRequest dto,
+                                                        @PathVariable Long familyId) {
+        petService.validatePetNameInFamily(userDetails, dto, familyId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/ValidatePetNameInFamilyRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/ValidatePetNameInFamilyRequest.java
@@ -1,0 +1,12 @@
+package org.retriever.server.dailypet.domain.pet.dto.request;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ValidatePetNameInFamilyRequest {
+
+    private String petName;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.enums.Gender;
 import org.retriever.server.dailypet.domain.pet.enums.PetStatus;
@@ -45,4 +46,8 @@ public class Pet extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petKindId", nullable = false)
     private PetKind petkind;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "familyId", nullable = false)
+    private Family family;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -1,9 +1,6 @@
 package org.retriever.server.dailypet.domain.pet.entity;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.enums.Gender;
@@ -16,6 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Pet extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -1,0 +1,48 @@
+package org.retriever.server.dailypet.domain.pet.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.pet.enums.Gender;
+import org.retriever.server.dailypet.domain.pet.enums.PetStatus;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pet extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long petId;
+
+    @Column(nullable = false, length = 50)
+    private String petName;
+
+    private String profileImageUrl;
+
+    private LocalDateTime birthDate;
+
+    private Double weight;
+
+    @Column(unique = true, length = 50)
+    private String registerNumber;
+
+    @Column(nullable = false)
+    private Boolean isNeutered;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private PetStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "petKindId", nullable = false)
+    private PetKind petkind;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/PetKind.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/PetKind.java
@@ -1,0 +1,36 @@
+package org.retriever.server.dailypet.domain.pet.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.pet.enums.PetType;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PetKind extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long petKindId;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String petKindName; // 품종 이름
+
+    @Lob
+    @Column(nullable = false)
+    private String information;
+
+    @Enumerated(EnumType.STRING)
+    private PetType petType; // 강아지 or 고양이
+
+    @OneToMany(mappedBy = "petKind")
+    private List<Pet> petList = new ArrayList<>();
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/enums/Gender.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/enums/Gender.java
@@ -1,0 +1,6 @@
+package org.retriever.server.dailypet.domain.pet.enums;
+
+public enum Gender {
+    MALE, // 수컷
+    FEMALE // 암컷
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/enums/PetStatus.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/enums/PetStatus.java
@@ -1,0 +1,6 @@
+package org.retriever.server.dailypet.domain.pet.enums;
+
+public enum PetStatus {
+    ACTIVE, // 활성화
+    DELETED // 삭제
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/enums/PetType.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/enums/PetType.java
@@ -1,0 +1,6 @@
+package org.retriever.server.dailypet.domain.pet.enums;
+
+public enum PetType {
+    DOG, // 강아지
+    CAT // 고양이
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/exception/DuplicatePetNameInFamilyException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/exception/DuplicatePetNameInFamilyException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.pet.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicatePetNameInFamilyException extends PetException {
+
+    private static final String ERROR_CODE = "PET-001";
+    private static final String MESSAGE = "가족 내 중복된 반려동물 이름이 있습니다.";
+    private static final HttpStatus STATUS = HttpStatus.CONFLICT;
+
+    public DuplicatePetNameInFamilyException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/exception/PetException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/exception/PetException.java
@@ -1,0 +1,11 @@
+package org.retriever.server.dailypet.domain.pet.exception;
+
+import org.retriever.server.dailypet.global.error.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class PetException extends ApplicationException {
+
+    public PetException(String errorCode, String message, HttpStatus httpStatus) {
+        super(errorCode, message, httpStatus);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetKindRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetKindRepository.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.pet.repository;
+
+import org.retriever.server.dailypet.domain.pet.entity.PetKind;
+import org.retriever.server.dailypet.domain.pet.enums.PetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PetKindRepository extends JpaRepository<PetKind, Long> {
+
+    Optional<PetKind> findByPetKindName(String petKindName);
+
+    Optional<PetKind> findByPetTypeOrderByPetKindName(PetType petType); // 이름 순으로 품종 정보 조회
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetRepository.java
@@ -1,0 +1,7 @@
+package org.retriever.server.dailypet.domain.pet.repository;
+
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
@@ -1,0 +1,27 @@
+package org.retriever.server.dailypet.domain.pet.service;
+
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
+import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
+import org.retriever.server.dailypet.domain.pet.exception.DuplicatePetNameInFamilyException;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PetService {
+
+    private final FamilyRepository familyRepository;
+
+    // TODO : 멤버 정보를 이용해서 속한 가족 정보를 바로 참조하는 쿼리 작성 (현재는 familyMember를 거쳐야함)
+    public void validatePetNameInFamily(CustomUserDetails userDetails, ValidatePetNameInFamilyRequest dto, Long familyId) {
+        Family family = familyRepository.findById(familyId).orElseThrow(FamilyNotFoundException::new);
+
+        if (family.getPetList().stream()
+                .anyMatch(pet -> pet.getPetName().equals(dto.getPetName()))) {
+            throw new DuplicatePetNameInFamilyException();
+        }
+    }
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-214
- **관련 문서** : N/A

## Changes 

- 반려동물 entity 설정 - Pet, PetKind (품종 정보)
- Pet : PetKind = N:1 연관관계 설정 (반려동물 당 품종 정보 1개)
- Pet : Family = N:1 연관관계 설정 (반려동물 당 속한 가족 1개)
- 가족 내 반려동물 이름 검증 API

## Test Checklist

- [ ] todo

## To Client

- 반려동물 도메인 세팅, 반려동물 이름 검증 API 개발했습니다.
- 저번에 이야기했던 것처럼 일단 request URL에 familyId를 넣었는데 jwtToken 정보로 가족 정보까지 조회할지 논의 필요
- 품종 정보 데이터 정의 필요 (어떤 견종, 묘종 제공할지?)
