### PR TITLE
Refactor: SnsLoginRequest type 추가 및 로직 변경

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -28,6 +28,7 @@ public class MemberController {
             "새로운 회원일 경우 회원 등록 페이지로 이동")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "기존 회원이므로 로그인 진행"),
+            @ApiResponse(responseCode = "400", description = "다른 Sns 계정으로 이미 가입한 회원"),
             @ApiResponse(responseCode = "401", description = "새로운 회원으로 회원 등록 진행"),
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SnsLoginRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SnsLoginRequest.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.member.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.retriever.server.dailypet.domain.member.enums.ProviderType;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
@@ -18,4 +19,6 @@ public class SnsLoginRequest {
     @NotEmpty
     @Email
     private String email;
+
+    private ProviderType providerType;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/exception/DifferentProviderTypeException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/exception/DifferentProviderTypeException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DifferentProviderTypeException extends MemberException{
+
+    private static final String ERROR_CODE = "MEMBER-004";
+    private static final String MESSAGE = "다른 SNS 계정으로 이미 가입된 회원입니다. 해당 SNS으로 로그인하세요.";
+    private static final HttpStatus STATUS = HttpStatus.BAD_REQUEST;
+
+    public DifferentProviderTypeException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.exception.DifferentProviderTypeException;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberException;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberNicknameException;
 import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
@@ -26,6 +27,10 @@ public class MemberService {
     public SnsLoginResponse checkMemberAndLogin(SnsLoginRequest dto) {
         Member member = memberRepository.findByEmail(dto.getEmail())
                 .orElseThrow(MemberNotFoundException::new);
+
+        if (!member.getProviderType().equals(dto.getProviderType())) {
+            throw new DifferentProviderTypeException();
+        }
         String token = jwtTokenProvider.createToken(dto.getEmail());
 
         return SnsLoginResponse.builder()

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -26,6 +26,7 @@ public class MemberFactory {
         return SnsLoginRequest.builder()
                 .snsNickName("test")
                 .email("test@naver.com")
+                .providerType(ProviderType.KAKAO)
                 .build();
     }
 


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/19
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- SnsLoginRequest에 Provider Type 추가
- 카카오로 회원가입되어 있는 계정이 동일한 정보로 네이버로 로그인할 경우 예외 발생

## Test Checklist

- [x] todo

## To Client

- type 비교 로직 추가 : 카카오로 회원가입한 회원 -> 네이버로 로그인 시도 (동일한 이메일) -> 이미 가입된 계정입니다.
