### PR TITLE
Refactor: 회원 가입 시 프로필 정보 추가 사용 동의 필드 추가

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.Size;
 public class SignUpRequest {
 
     @NotEmpty
-    @Size(max = 10)
+    @Size(max = 20)
     private String snsNickName;
 
     @NotEmpty
@@ -26,4 +26,8 @@ public class SignUpRequest {
     private ProviderType providerType;
 
     private String deviceToken;
+
+    private Boolean isPushAgree;
+
+    private Boolean isProfileInformationAgree;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -84,6 +84,8 @@ public class Member extends BaseTimeEntity {
                 .profileImageUrl(signUpRequest.getProfileImageUrl())
                 .type(signUpRequest.getProviderType())
                 .deviceToken(signUpRequest.getDeviceToken())
+                .isPushAgree((signUpRequest.getIsPushAgree()))
+                .isProfileInformationAgree(signUpRequest.getIsProfileInformationAgree())
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -22,11 +22,17 @@ public class Member extends BaseTimeEntity {
     @Column(name = "memberId")
     private Long id;
 
+    // 개인정보 이용 약관
     private Boolean isPersonalInformationAgree;
 
+    // 서비스 이용 약관
     private Boolean isToSAgree;
 
+    // 광고성 푸시알람 수신 동의
     private Boolean isPushAgree;
+
+    // 프로필 정보 추가 수집 동의
+    private Boolean isProfileInformationAgree;
 
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus;
@@ -56,10 +62,11 @@ public class Member extends BaseTimeEntity {
     private List<FamilyMember> familyMemberList;
 
     @Builder
-    public Member(String email, String nickName, String profileImageUrl, ProviderType type, String deviceToken) {
+    public Member(String email, String nickName, String profileImageUrl, ProviderType type, String deviceToken, Boolean isPushAgree, Boolean isProfileInformationAgree) {
         this.isPersonalInformationAgree = true;
         this.isToSAgree = true;
-        this.isPushAgree = false;
+        this.isPushAgree = isPushAgree;
+        this.isProfileInformationAgree = isProfileInformationAgree;
         this.accountStatus = AccountStatus.ACTIVE;
         this.email = email;
         this.nickName = nickName;

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -55,7 +55,8 @@ public class MemberFactory {
                 .deviceToken("abcde12345")
                 .profileImageUrl("S3URL")
                 .providerType(ProviderType.KAKAO)
+                .isPushAgree(Boolean.TRUE)
+                .isProfileInformationAgree(Boolean.TRUE)
                 .build();
     }
-
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -33,7 +33,8 @@ class MemberTest {
         assertThat(newMember.getRoleType()).isEqualTo(RoleType.MEMBER);
         assertThat(newMember.getIsPersonalInformationAgree()).isTrue();
         assertThat(newMember.getIsToSAgree()).isTrue();
-        assertThat(newMember.getIsPushAgree()).isFalse();
+        assertThat(newMember.getIsPushAgree()).isTrue();
+        assertThat(newMember.getIsProfileInformationAgree()).isTrue();
 
         assertThat(newMember.getFamilyRoleName()).isEqualTo("별명을 입력해주세요!");
         assertThat(newMember.getPassword()).isNull();


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/23
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- Member entity 프로필 정보 추가 사용 동의 필드 추가
- 닉네임 검증 사이즈 20으로 수정
- SignUpRequest 요청 시 광고성 푸시 알람 동의, 프로필 정보 추가 사용 동의 필드 추가
- Member 테스트 수정

## Test Checklist

- [x] todo

## To Client

- 닉네임 검증 사이즈 20으로 수정했고, 약관 동의 중 선택 동의 2가지는 요청 필드에서 받도록 수정했습니다.
- 필수 동의 2개는 default True로 저장
