### PR TITLE
Refactor: JwtAuthenticationEntryPoint, JwtAccessDeniedHandler exception response 통일

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/global/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/jwt/JwtAccessDeniedHandler.java
@@ -26,7 +26,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        log.warn("AccessDeniedHandler : {}", accessDeniedException.getClass().getSimpleName());
+        log.warn("AccessDeniedHandler : {} | {}", accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage());
         response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/retriever/server/dailypet/global/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/jwt/JwtAccessDeniedHandler.java
@@ -1,5 +1,11 @@
 package org.retriever.server.dailypet.global.config.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.retriever.server.dailypet.global.error.exception.dto.ApiErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -10,9 +16,22 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+    private static final String ERROR_CODE = "AUTH-001";
+    private static final String MESSAGE = "권한이 없는 회원입니다.";
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        log.warn("AccessDeniedHandler : {}", accessDeniedException.getClass().getSimpleName());
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        String responseJson = objectMapper.writeValueAsString(ApiErrorResponse.of(ERROR_CODE, MESSAGE));
+
+        response.getWriter().write(responseJson);
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,11 @@
 package org.retriever.server.dailypet.global.config.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.retriever.server.dailypet.global.error.exception.dto.ApiErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -10,10 +16,22 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+    private static final String ERROR_CODE = "AUTH-002";
+    private static final String MESSAGE = "인증에 실패한 회원입니다.";
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        log.warn("AuthenticationEntryPoint : {} | {}", authException.getClass().getSimpleName(), authException.getMessage());
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        String responseJson = objectMapper.writeValueAsString(ApiErrorResponse.of(ERROR_CODE, MESSAGE));
+
+        response.getWriter().write(responseJson);
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/error/exception/dto/ApiErrorResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/global/error/exception/dto/ApiErrorResponse.java
@@ -19,4 +19,8 @@ public class ApiErrorResponse {
         this.errorCode = errorCode;
         this.message = message;
     }
+
+    public static ApiErrorResponse of(String errorCode, String message) {
+        return new ApiErrorResponse(errorCode, message);
+    }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 토큰 관련 401, 403 에러 응답 통일

## Test Checklist

- 

## To Client

- 토큰 관련 예외 응답이 다른 api의 응답과 같도록 수정했습니다.
