### PR TITLE
PET-107, PET-119 AWS S3 기능 추가, 사용자 프로필 변경 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 	// slack x log
 	implementation "com.github.maricn:logback-slack-appender:1.4.0"
 
+	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-aws
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -8,13 +8,18 @@ import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
+import org.retriever.server.dailypet.domain.member.dto.response.EditProfileImageResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.service.MemberService;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -59,6 +64,19 @@ public class MemberController {
     @PostMapping("/auth/sign-up")
     public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestBody @Valid SignUpRequest dto) {
         return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto));
+    }
+
+    @Operation(summary = "회원 프로필 사진 수정", description = "회원의 프로필 사진을 수정한다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 프로필 사진 정상 수정"),
+            @ApiResponse(responseCode = "400", description = "회원 프로필 사진 수정 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+
+    @PatchMapping("member/mypage/profile-image")
+    public ResponseEntity<EditProfileImageResponse> editProfileImage(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                     @RequestPart MultipartFile image) throws IOException {
+        return ResponseEntity.ok(memberService.editProfileImage(userDetails, image));
     }
 
     @GetMapping("/test")

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/EditProfileImageResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/EditProfileImageResponse.java
@@ -1,0 +1,18 @@
+package org.retriever.server.dailypet.domain.member.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EditProfileImageResponse {
+
+    private String profileImageUrl;
+
+    public static EditProfileImageResponse from(String profileImageUrl) {
+        return EditProfileImageResponse.builder()
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -96,4 +96,8 @@ public class Member extends BaseTimeEntity {
     public void changeFamilyRoleName(String familyRoleName) {
         this.familyRoleName = familyRoleName;
     }
+
+    public void editProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/config/S3Config.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package org.retriever.server.dailypet.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+}

--- a/src/main/java/org/retriever/server/dailypet/global/error/exception/GlobalExceptionControllerAdvice.java
+++ b/src/main/java/org/retriever/server/dailypet/global/error/exception/GlobalExceptionControllerAdvice.java
@@ -43,8 +43,8 @@ public class GlobalExceptionControllerAdvice {
     public ResponseEntity<ApiErrorResponse> runtimeException(RuntimeException exception) {
         String errorCode = INTERNAL_SERVER_ERROR_CODE;
         String message = "내부 서버 에러입니다.";
-        log.error("Exception : {} ErrorCode : {} Message : {}",
-                exception.getClass().getSimpleName(), errorCode, message);
+        log.error("Exception : {} ErrorCode : {} Message : {} Detail : {}",
+                exception.getClass().getSimpleName(), errorCode, message, exception.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                 .body(new ApiErrorResponse(errorCode, message));

--- a/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3FileUploader.java
+++ b/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3FileUploader.java
@@ -1,0 +1,62 @@
+package org.retriever.server.dailypet.global.utils.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3FileUploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
+
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + uploadFile.getName();
+        log.info("Upload fileName : {}", fileName);
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+        }
+        return Optional.of(convertFile);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   h2:
     console:
       enabled: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   datasource:
     url: jdbc:h2:mem:testdb
@@ -25,3 +29,16 @@ logging:
   slack:
     webhook-uri: ${SLACK_WEBHOOK_URI}
   config: classpath:logback-slack.xml
+
+cloud:
+  aws:
+    stack:
+      auto: false
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+      instance-profile: true
+    s3:
+      bucket: dailypet-test-bucket


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-107, PET-119
- **관련 문서** : N/A

## Changes 

- AWS S3 관련 코드 추가
- 사용자 프로필 이미지 변경 API 추가
- 우선 test bucket으로 업로드 테스트 성공

## Test Checklist

- [ ] 추후 배포 시 bucket 다시 설정
- [ ] aws s3 관련 accessKey, secretKey 저장
- [ ] s3 관련 예외 처리하기
- [ ] s3 파일 이름 설정

## To Client

- 클라이언트는 MultiPartFile을 보내면 됩니다.
- 현재 다른 등록 API들 (유저, 가족, 반려동물)에 MultiPart로 받는 건 적용하지 않았습니다.