### PR TITLE
PET-176 챙겨주기 등록 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -77,4 +77,9 @@ public class Pet extends BaseTimeEntity {
     public void setFamily(Family family) {
         this.family = family;
     }
+
+    public void registerPetCare(PetCare petCare) {
+        this.petCareList.add(petCare);
+        petCare.addPet(this);
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/exception/PetNotFoundException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/exception/PetNotFoundException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.pet.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PetNotFoundException extends PetException{
+
+    private static final String ERROR_CODE = "PET-003";
+    private static final String MESSAGE = "해당하는 반려동물이 없습니다.";
+    private static final HttpStatus STATUS = HttpStatus.BAD_REQUEST;
+
+    public PetNotFoundException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
@@ -1,0 +1,37 @@
+package org.retriever.server.dailypet.domain.petcare.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.service.PetCareService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "PetCare API")
+public class PetCareController {
+
+    private final PetCareService petCareService;
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "챙겨주기 항목 등록", description = "해당 반려동물 기준으로 챙겨주기 항목을 등록한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "챙겨주기 항목 정상 등록"),
+            @ApiResponse(responseCode = "400", description = "챙겨주기 항목 등록 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/pets/{petId}/pet-care")
+    public ResponseEntity<Void> registerPetCare(@PathVariable Long petId, @RequestBody @Valid CreatePetCareRequest dto) {
+        petCareService.registerPetCare(petId, dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/request/CreatePetCareRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/request/CreatePetCareRequest.java
@@ -1,0 +1,19 @@
+package org.retriever.server.dailypet.domain.petcare.dto.request;
+
+import lombok.*;
+import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreatePetCareRequest {
+
+    private String careName;
+
+    private List<CustomDayOfWeek> dayOfWeeks;
+
+    private int repeatCnt;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
@@ -3,6 +3,7 @@ package org.retriever.server.dailypet.domain.petcare.entity;
 import lombok.*;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
 import org.retriever.server.dailypet.domain.petcare.enums.PetCareStatus;
 
 import javax.persistence.*;
@@ -22,7 +23,7 @@ public class PetCare extends BaseTimeEntity {
 
     private String careName;
 
-    private int alarmSetting;
+    private int repeatCnt;
 
     private Boolean isPushAgree;
 
@@ -33,11 +34,29 @@ public class PetCare extends BaseTimeEntity {
     @JoinColumn(name = "petId", nullable = false)
     private Pet pet;
 
-    @OneToMany(mappedBy = "petCare")
+    @OneToMany(mappedBy = "petCare", cascade = CascadeType.PERSIST)
     @Builder.Default
     private List<PetCareAlarm> petCareAlarmList = new ArrayList<>();
 
     @OneToMany(mappedBy = "petCare")
     @Builder.Default
     private List<CareLog> careLogList = new ArrayList<>();
+
+    public static PetCare from(CreatePetCareRequest dto) {
+        return PetCare.builder()
+                .careName(dto.getCareName())
+                .repeatCnt(dto.getRepeatCnt())
+                .isPushAgree(false)
+                .petCareStatus(PetCareStatus.ACTIVE)
+                .build();
+    }
+
+    public void addPet(Pet pet) {
+        this.pet = pet;
+    }
+
+    public void addPetCareAlarm(PetCareAlarm petCareAlarm) {
+        this.petCareAlarmList.add(petCareAlarm);
+        petCareAlarm.setPetCare(this);
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareAlarm.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareAlarm.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.petcare.entity;
 
 import lombok.*;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
 import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
 
 import javax.persistence.*;
@@ -20,9 +21,17 @@ public class PetCareAlarm extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private CustomDayOfWeek dayOfWeek;
 
-    private int repeatCnt;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petCareId", nullable = false)
     private PetCare petCare;
+
+    public static PetCareAlarm from(CustomDayOfWeek dayOfWeek) {
+        return PetCareAlarm.builder()
+                .dayOfWeek(dayOfWeek)
+                .build();
+    }
+
+    public void setPetCare(PetCare petCare) {
+        this.petCare = petCare;
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/enums/CustomDayOfWeek.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/enums/CustomDayOfWeek.java
@@ -1,11 +1,11 @@
 package org.retriever.server.dailypet.domain.petcare.enums;
 
 public enum CustomDayOfWeek {
-    MONDAY,
-    TUESDAY,
-    WEDNESDAY,
-    THURSDAY,
-    FRIDAY,
-    SATURDAY,
-    SUNDAY
+    MON,
+    TUE,
+    WED,
+    THU,
+    FRI,
+    SAT,
+    SUN
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
@@ -1,0 +1,44 @@
+package org.retriever.server.dailypet.domain.petcare.service;
+
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.retriever.server.dailypet.domain.pet.exception.PetNotFoundException;
+import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCareAlarm;
+import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
+import org.retriever.server.dailypet.domain.petcare.repository.PetCareRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PetCareService {
+
+    private final PetRepository petRepository;
+    private final PetCareRepository petCareRepository;
+
+    @Transactional
+    public void registerPetCare(Long petId, CreatePetCareRequest dto) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(PetNotFoundException::new);
+
+        PetCare petCare = PetCare.from(dto);
+
+        List<CustomDayOfWeek> dayOfWeeks = dto.getDayOfWeeks();
+
+        for (CustomDayOfWeek dayOfWeek : dayOfWeeks) {
+            PetCareAlarm petCareAlarm = PetCareAlarm.from(dayOfWeek);
+            petCare.addPetCareAlarm(petCareAlarm);
+        }
+
+        pet.registerPetCare(petCare);
+
+        // CascadeType.PERSIST를 통해 연관된 petCareAlarm 포함해서 저장
+        petCareRepository.save(petCare);
+    }
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-176
- **관련 문서** : N/A

## Changes 

- 케어 주기용 요일 ENUM 추가(MON, TUE, WED, THU, FRI, SAT, SUN)
- 챙겨주기 등록을 하면 PetCare 생성, 반복 요일에 해당하는 PetCareAlarm 생성
- CascadeType.PERSIST로 PetCare 저장 시 Alarm 영속성 전이

## Test Checklist

-

## To Client

- 케어 주기에 해당하는 요일 ENUM 추가했고, Request시 필드 List type으로 요청하면 됩니다.
`
{
  "careName": "운동",
  "dayOfWeeks": [
    "MON",
    "FRI"
  ],
  "repeatCnt": 1
}
`