### PR TITLE
PET-195 메인 페이지 상단 정보 조회 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
+import org.retriever.server.dailypet.domain.member.dto.response.CalculateDayResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.EditProfileImageResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
@@ -72,12 +73,24 @@ public class MemberController {
             @ApiResponse(responseCode = "400", description = "회원 프로필 사진 수정 실패"),
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
-
-    @PatchMapping("member/mypage/profile-image")
+    @PatchMapping("/member/mypage/profile-image")
     public ResponseEntity<EditProfileImageResponse> editProfileImage(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                      @RequestPart MultipartFile image) throws IOException {
         return ResponseEntity.ok(memberService.editProfileImage(userDetails, image));
     }
+
+    @Operation(summary = "메인 페이지 - 반려동물과 보낸 시간 조회", description = "나와 반려동물이 만난지 얼마나 됐는지 날짜를 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정상 조회"),
+            @ApiResponse(responseCode = "400", description = "조회 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/main/pets/{petId}/days")
+    public ResponseEntity<CalculateDayResponse> calculateDayOfFirstMeet(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                        @PathVariable Long petId) {
+        return ResponseEntity.ok(memberService.calculateDayOfFirstMeet(userDetails, petId));
+    }
+
 
     @GetMapping("/test")
     public String test() {

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/CalculateDayResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/CalculateDayResponse.java
@@ -1,0 +1,24 @@
+package org.retriever.server.dailypet.domain.member.dto.response;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@AllArgsConstructor
+public class CalculateDayResponse {
+
+    private String userName;
+
+    private String petName;
+
+    private int calculatedDay;
+
+    public static CalculateDayResponse of(String userName, String petName, int diff) {
+        return CalculateDayResponse.builder()
+                .userName(userName)
+                .petName(petName)
+                .calculatedDay(diff)
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/RegisterPetRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/RegisterPetRequest.java
@@ -4,7 +4,7 @@ import lombok.*;
 import org.retriever.server.dailypet.domain.pet.enums.Gender;
 import org.retriever.server.dailypet.domain.pet.enums.PetType;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Builder
 @Getter
@@ -20,7 +20,7 @@ public class RegisterPetRequest {
 
     private Gender gender;
 
-    private LocalDateTime birthDate;
+    private LocalDate birthDate;
 
     private Long petKindId;
 

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -9,7 +9,7 @@ import org.retriever.server.dailypet.domain.pet.enums.PetStatus;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class Pet extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    private LocalDateTime birthDate;
+    private LocalDate birthDate;
 
     private Double weight;
 

--- a/src/main/java/org/retriever/server/dailypet/global/utils/LocalDateTimeUtils.java
+++ b/src/main/java/org/retriever/server/dailypet/global/utils/LocalDateTimeUtils.java
@@ -1,0 +1,15 @@
+package org.retriever.server.dailypet.global.utils;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+public class LocalDateTimeUtils {
+
+    public static int calculateDaysFromNow(LocalDate date) {
+        LocalDate now = LocalDate.now();
+
+        Period period = Period.between(date, now);
+
+        return Math.abs(period.getDays());
+    }
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-195
- **관련 문서** : N/A

## Changes 

- 기존 반려동물 등록 시 필드 LocalDateTime -> LocalDate로 변경 (yyyy-mn-dd 포맷)
- 날짜 관련 유틸 클래스 생성
- 메인 페이지 정보 조회 API

## Test Checklist

- 

## To Client

- 반려동물 등록 시 "2022-08-22" 형식으로 보내면 됩니다! (피그마와 동일)
- 기존 로직에는 2022-08-22T22:08:32처럼 시간까지 다 받고 있던 상황이라 수정했습니다.
- 날짜 계산 기준은 반려동물 등록 시 생일이랑 오늘 날짜 기준으로 datediff 계산했습니다. 
![image](https://user-images.githubusercontent.com/66156531/185872313-18a2410b-a9c4-45de-8f08-2f02e87300d2.png)

