### PR TITLE
PET-186 챙겨주기 1회 추가 API, CareLog 생성

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -6,6 +6,7 @@ import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.enums.Gender;
 import org.retriever.server.dailypet.domain.pet.enums.PetStatus;
+import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 
 import javax.persistence.*;
@@ -56,6 +57,10 @@ public class Pet extends BaseTimeEntity {
     @OneToMany(mappedBy = "pet")
     @Builder.Default
     private List<PetCare> petCareList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "pet")
+    @Builder.Default
+    private List<CareLog> careLogList = new ArrayList<>();
 
     public static Pet createPet(RegisterPetRequest dto) {
         return Pet.builder()

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
@@ -6,10 +6,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.dto.response.CheckPetCareResponse;
 import org.retriever.server.dailypet.domain.petcare.service.PetCareService;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -29,9 +31,22 @@ public class PetCareController {
             @ApiResponse(responseCode = "400", description = "챙겨주기 항목 등록 실패"),
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
-    @PostMapping("/pets/{petId}/pet-care")
+    @PostMapping("/pets/{petId}/care")
     public ResponseEntity<Void> registerPetCare(@PathVariable Long petId, @RequestBody @Valid CreatePetCareRequest dto) {
         petCareService.registerPetCare(petId, dto);
         return ResponseEntity.ok().build();
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "챙겨주기 항목 1회 체크", description = "해당 반려동물의 챙겨주기 항목을 체크한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "챙겨주기 정상 체크"),
+            @ApiResponse(responseCode = "400", description = "챙겨주기 체크 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/pets/{petId}/cares/{careId}/check")
+    public ResponseEntity<CheckPetCareResponse> checkPetCare(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                             @PathVariable Long petId, @PathVariable Long careId) {
+        return ResponseEntity.ok(petCareService.checkPetCare(userDetails, petId, careId));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/request/CreatePetCareRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/request/CreatePetCareRequest.java
@@ -15,5 +15,5 @@ public class CreatePetCareRequest {
 
     private List<CustomDayOfWeek> dayOfWeeks;
 
-    private int repeatCnt;
+    private int totalCountPerDay;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CheckPetCareResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CheckPetCareResponse.java
@@ -1,0 +1,16 @@
+package org.retriever.server.dailypet.domain.petcare.dto.response;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CheckPetCareResponse {
+
+    private Long petCareId;
+
+    private int currentCount;
+
+    private String memberNameWhoChecked;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
@@ -3,6 +3,7 @@ package org.retriever.server.dailypet.domain.petcare.entity;
 import lombok.*;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
 import javax.persistence.*;
 
@@ -24,4 +25,19 @@ public class CareLog extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId", nullable = false)
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "petId", nullable = false)
+    private Pet pet;
+
+    public static CareLog of(Member member, Pet pet, PetCare petCare) {
+        CareLog careLog = CareLog.builder()
+                .member(member)
+                .pet(pet)
+                .petCare(petCare)
+                .build();
+        member.getCareLogList().add(careLog);
+
+        return careLog;
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
@@ -5,6 +5,7 @@ import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
 import org.retriever.server.dailypet.domain.petcare.enums.PetCareStatus;
+import org.retriever.server.dailypet.domain.petcare.exception.CareCountExceededException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -23,9 +24,9 @@ public class PetCare extends BaseTimeEntity {
 
     private String careName;
 
-    private int curCnt;
+    private int currentCount;
 
-    private int repeatCnt;
+    private int totalCountPerDay;
 
     private Boolean isPushAgree;
 
@@ -47,7 +48,7 @@ public class PetCare extends BaseTimeEntity {
     public static PetCare from(CreatePetCareRequest dto) {
         return PetCare.builder()
                 .careName(dto.getCareName())
-                .repeatCnt(dto.getRepeatCnt())
+                .totalCountPerDay(dto.getTotalCountPerDay())
                 .isPushAgree(false)
                 .petCareStatus(PetCareStatus.ACTIVE)
                 .build();
@@ -60,5 +61,13 @@ public class PetCare extends BaseTimeEntity {
     public void addPetCareAlarm(PetCareAlarm petCareAlarm) {
         this.petCareAlarmList.add(petCareAlarm);
         petCareAlarm.setPetCare(this);
+    }
+
+    public void pushCareCheckButton() {
+        int after = this.currentCount + 1;
+        if (after > totalCountPerDay) {
+            throw new CareCountExceededException();
+        }
+        this.currentCount = after;
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
@@ -23,6 +23,8 @@ public class PetCare extends BaseTimeEntity {
 
     private String careName;
 
+    private int curCnt;
+
     private int repeatCnt;
 
     private Boolean isPushAgree;

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/exception/CareCountExceededException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/exception/CareCountExceededException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.petcare.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CareCountExceededException extends PetCareException{
+
+    private static final String ERROR_CODE = "CARE-002";
+    private static final String MESSAGE = "해당하는 챙겨주기의 할당량을 초과했습니다.";
+    private static final HttpStatus STATUS = HttpStatus.BAD_REQUEST;
+
+    public CareCountExceededException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/exception/PetCareNotFoundException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/exception/PetCareNotFoundException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.petcare.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PetCareNotFoundException extends PetCareException{
+
+    private static final String ERROR_CODE = "CARE-001";
+    private static final String MESSAGE = "해당하는 챙겨주기 항목이 존재하지 않습니다.";
+    private static final HttpStatus STATUS = HttpStatus.BAD_REQUEST;
+
+    public PetCareNotFoundException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
@@ -1,14 +1,22 @@
 package org.retriever.server.dailypet.domain.petcare.service;
 
 import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundException;
+import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.pet.exception.PetNotFoundException;
 import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.dto.response.CheckPetCareResponse;
+import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCareAlarm;
 import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
+import org.retriever.server.dailypet.domain.petcare.exception.PetCareNotFoundException;
+import org.retriever.server.dailypet.domain.petcare.repository.CareLogRepository;
 import org.retriever.server.dailypet.domain.petcare.repository.PetCareRepository;
+import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +29,8 @@ public class PetCareService {
 
     private final PetRepository petRepository;
     private final PetCareRepository petCareRepository;
+    private final CareLogRepository careLogRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void registerPetCare(Long petId, CreatePetCareRequest dto) {
@@ -40,5 +50,24 @@ public class PetCareService {
 
         // CascadeType.PERSIST를 통해 연관된 petCareAlarm 포함해서 저장
         petCareRepository.save(petCare);
+    }
+
+    // TODO 1회 체크 동시성 이슈 해결 필요 (가족들 공동 접근)
+    @Transactional
+    public CheckPetCareResponse checkPetCare(CustomUserDetails userDetails, Long petId, Long careId) {
+        Member member = memberRepository.findById(userDetails.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(PetNotFoundException::new);
+
+        PetCare petCare = petCareRepository.findById(careId).orElseThrow(PetCareNotFoundException::new);
+        petCare.pushCareCheckButton();
+
+        CareLog careLog = CareLog.of(member, pet, petCare);
+
+        careLogRepository.save(careLog);
+
+        return new CheckPetCareResponse(petId, petCare.getCurrentCount(), member.getFamilyRoleName());
     }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : PET-186
- **관련 문서** : N/A

## Changes 

- 챙겨주기 1회 추가 API
- 최대 횟수 초과하면 예외 발생
- 현재 횟수를 저장하기 위한 필드 추가

## Test Checklist

- [ ] 1회 취소 시 내가 한 기록만 삭제할 것인지, 아님 가족단위로 삭제할 것인지 고민
- [ ] 취소 시 로그에 취소 로그 추가 (통계를 위해서)
- [ ] careLog에 ENUM 필드 추가 필요

## To Client

- 나중에 만나서 챙겨주기 등록 시 필요한 필드를 정리해보면 좋을 것 같습니다.
- 오늘 api 짜보니까 ui에 부족한 필드들이 보여서요!
- 추가로 챙겨주기 이후 response에는 챙겨주기 id, 챙겨주기 반영된 결과 횟수, 누가 챙겨줬는지 멤버 이름 리턴합니다.
- 응답값은 나중에 맞춰보는거로!
![image](https://user-images.githubusercontent.com/66156531/185940483-530f759f-4f38-4bee-b765-9b1a068db4e6.png)
