### PR TITLE
PET-187 챙겨주기 1회 취소 API, CareLog Check, Cancel 상태 추가

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.dto.response.CancelPetCareResponse;
 import org.retriever.server.dailypet.domain.petcare.dto.response.CheckPetCareResponse;
 import org.retriever.server.dailypet.domain.petcare.service.PetCareService;
 import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
@@ -48,5 +49,18 @@ public class PetCareController {
     public ResponseEntity<CheckPetCareResponse> checkPetCare(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                              @PathVariable Long petId, @PathVariable Long careId) {
         return ResponseEntity.ok(petCareService.checkPetCare(userDetails, petId, careId));
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "챙겨주기 항목 1회 취소", description = "해당 반려동물의 챙겨주기 항목을 취소한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "챙겨주기 정상 취소"),
+            @ApiResponse(responseCode = "400", description = "챙겨주기 취소 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/pets/{petId}/cares/{careId}/cancel")
+    public ResponseEntity<CancelPetCareResponse> cancelPetCare(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                               @PathVariable Long petId, @PathVariable Long careId) {
+        return ResponseEntity.ok(petCareService.cancelPetCare(userDetails, petId, careId));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CancelPetCareResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CancelPetCareResponse.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.petcare.dto.response;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CancelPetCareResponse {
+
+    private Long petCareId;
+
+    private int currentCount;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.retriever.server.dailypet.domain.petcare.enums.CareLogStatus;
 
 import javax.persistence.*;
 
@@ -18,6 +19,9 @@ public class CareLog extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long careLogId;
 
+    @Enumerated(EnumType.STRING)
+    private CareLogStatus careLogStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petCareId", nullable = false)
     private PetCare petCare;
@@ -30,11 +34,12 @@ public class CareLog extends BaseTimeEntity {
     @JoinColumn(name = "petId", nullable = false)
     private Pet pet;
 
-    public static CareLog of(Member member, Pet pet, PetCare petCare) {
+    public static CareLog of(Member member, Pet pet, PetCare petCare, CareLogStatus careLogStatus) {
         CareLog careLog = CareLog.builder()
                 .member(member)
                 .pet(pet)
                 .petCare(petCare)
+                .careLogStatus(careLogStatus)
                 .build();
         member.getCareLogList().add(careLog);
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
@@ -6,6 +6,7 @@ import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
 import org.retriever.server.dailypet.domain.petcare.enums.PetCareStatus;
 import org.retriever.server.dailypet.domain.petcare.exception.CareCountExceededException;
+import org.retriever.server.dailypet.domain.petcare.exception.CareCountIsZeroException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -67,6 +68,14 @@ public class PetCare extends BaseTimeEntity {
         int after = this.currentCount + 1;
         if (after > totalCountPerDay) {
             throw new CareCountExceededException();
+        }
+        this.currentCount = after;
+    }
+
+    public void cancelCareCheckButton() {
+        int after = this.currentCount - 1;
+        if (after < 0) {
+            throw new CareCountIsZeroException();
         }
         this.currentCount = after;
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/enums/CareLogStatus.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/enums/CareLogStatus.java
@@ -1,0 +1,6 @@
+package org.retriever.server.dailypet.domain.petcare.enums;
+
+public enum CareLogStatus {
+    CHECK,
+    CANCEL
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/exception/CareCountIsZeroException.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/exception/CareCountIsZeroException.java
@@ -1,0 +1,14 @@
+package org.retriever.server.dailypet.domain.petcare.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CareCountIsZeroException extends PetCareException {
+
+    private static final String ERROR_CODE = "CARE-003";
+    private static final String MESSAGE = "해당하는 챙겨주기의 횟수가 0입니다.";
+    private static final HttpStatus STATUS = HttpStatus.BAD_REQUEST;
+
+    public CareCountIsZeroException() {
+        super(ERROR_CODE, MESSAGE, STATUS);
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
@@ -8,10 +8,12 @@ import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.pet.exception.PetNotFoundException;
 import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.dto.response.CancelPetCareResponse;
 import org.retriever.server.dailypet.domain.petcare.dto.response.CheckPetCareResponse;
 import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCareAlarm;
+import org.retriever.server.dailypet.domain.petcare.enums.CareLogStatus;
 import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
 import org.retriever.server.dailypet.domain.petcare.exception.PetCareNotFoundException;
 import org.retriever.server.dailypet.domain.petcare.repository.CareLogRepository;
@@ -64,7 +66,7 @@ public class PetCareService {
         PetCare petCare = petCareRepository.findById(careId).orElseThrow(PetCareNotFoundException::new);
         petCare.pushCareCheckButton();
 
-        CareLog careLog = CareLog.of(member, pet, petCare);
+        CareLog careLog = CareLog.of(member, pet, petCare, CareLogStatus.CHECK);
 
         careLogRepository.save(careLog);
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
@@ -56,20 +56,37 @@ public class PetCareService {
 
     // TODO 1회 체크 동시성 이슈 해결 필요 (가족들 공동 접근)
     @Transactional
-    public CheckPetCareResponse checkPetCare(CustomUserDetails userDetails, Long petId, Long careId) {
+    public CheckPetCareResponse checkPetCare(CustomUserDetails userDetails, Long petId, Long petCareId) {
         Member member = memberRepository.findById(userDetails.getId())
                 .orElseThrow(MemberNotFoundException::new);
 
         Pet pet = petRepository.findById(petId)
                 .orElseThrow(PetNotFoundException::new);
 
-        PetCare petCare = petCareRepository.findById(careId).orElseThrow(PetCareNotFoundException::new);
+        PetCare petCare = petCareRepository.findById(petCareId).orElseThrow(PetCareNotFoundException::new);
         petCare.pushCareCheckButton();
 
         CareLog careLog = CareLog.of(member, pet, petCare, CareLogStatus.CHECK);
 
         careLogRepository.save(careLog);
 
-        return new CheckPetCareResponse(petId, petCare.getCurrentCount(), member.getFamilyRoleName());
+        return new CheckPetCareResponse(petCareId, petCare.getCurrentCount(), member.getFamilyRoleName());
+    }
+
+    public CancelPetCareResponse cancelPetCare(CustomUserDetails userDetails, Long petId, Long petCareId) {
+        Member member = memberRepository.findById(userDetails.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(PetNotFoundException::new);
+
+        PetCare petCare = petCareRepository.findById(petCareId).orElseThrow(PetCareNotFoundException::new);
+        petCare.cancelCareCheckButton();
+
+        CareLog careLog = CareLog.of(member, pet, petCare, CareLogStatus.CANCEL);
+
+        careLogRepository.save(careLog);
+
+        return new CancelPetCareResponse(petCareId, petCare.getCurrentCount());
     }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/36 https://github.com/SWM-Retriever/Server/issues/37
- **JIRA 백로그** : PET-187
- **관련 문서** : N/A

## Changes 

- 챙겨주기 1회 취소 API
- 0회일때 취소하면 예외 발생
- 우선 가족 단위로 취소할 수 있도록 작성
- CareLog에 Status Enum 추가 (Check, Cancel)

## Test Checklist

-

## To Client

- 회의한 대로 가족 단위 취소로 개발했습니다.
