### PR TITLE
Refactor: 이미지 전송 Multipart로 변경

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -17,8 +17,10 @@ import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -64,8 +66,9 @@ public class FamilyController {
     })
     @PostMapping("/family")
     public ResponseEntity<CreateFamilyResponse> createFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                             @RequestBody @Valid CreateFamilyRequest dto) {
-        return ResponseEntity.ok(familyService.createFamily(userDetails, dto));
+                                                             @RequestBody @Valid CreateFamilyRequest dto,
+                                                             @RequestPart MultipartFile image) throws IOException {
+        return ResponseEntity.ok(familyService.createFamily(userDetails, dto, image));
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)

--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -66,7 +66,7 @@ public class FamilyController {
     })
     @PostMapping("/family")
     public ResponseEntity<CreateFamilyResponse> createFamily(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                             @RequestBody @Valid CreateFamilyRequest dto,
+                                                             @RequestPart @Valid CreateFamilyRequest dto,
                                                              @RequestPart MultipartFile image) throws IOException {
         return ResponseEntity.ok(familyService.createFamily(userDetails, dto, image));
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/CreateFamilyRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/request/CreateFamilyRequest.java
@@ -11,6 +11,4 @@ public class CreateFamilyRequest {
     private String familyName;
 
     private String familyRoleName;
-
-    private String profileImageUrl;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
@@ -40,12 +40,12 @@ public class Family extends BaseTimeEntity {
     @Builder.Default
     private List<Pet> petList = new ArrayList<>();
 
-    public static Family createFamily(CreateFamilyRequest dto, String invitationCode) {
+    public static Family createFamily(CreateFamilyRequest dto, String invitationCode, String profileImageUrl) {
         return Family.builder()
                 .familyName(dto.getFamilyName())
                 .familyStatus(FamilyStatus.ACTIVE)
                 .invitationCode(invitationCode)
-                .profileImageUrl(dto.getProfileImageUrl())
+                .profileImageUrl(profileImageUrl)
                 .familyMemberList(new ArrayList<>())
                 .build();
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -63,8 +63,9 @@ public class MemberController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/auth/sign-up")
-    public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestBody @Valid SignUpRequest dto) {
-        return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto));
+    public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestBody @Valid SignUpRequest dto,
+                                                                   @RequestPart MultipartFile image) throws IOException {
+        return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto, image));
     }
 
     @Operation(summary = "회원 프로필 사진 수정", description = "회원의 프로필 사진을 수정한다")

--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -63,7 +63,7 @@ public class MemberController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/auth/sign-up")
-    public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestBody @Valid SignUpRequest dto,
+    public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestPart @Valid SignUpRequest dto,
                                                                    @RequestPart MultipartFile image) throws IOException {
         return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto, image));
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
@@ -20,9 +20,6 @@ public class SignUpRequest {
     @Email
     private String email;
 
-    @NotEmpty
-    private String profileImageUrl;
-
     private ProviderType providerType;
 
     private String deviceToken;

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -85,11 +85,11 @@ public class Member extends BaseTimeEntity {
         this.deviceToken = deviceToken;
     }
 
-    public static Member createNewMember(SignUpRequest signUpRequest) {
+    public static Member createNewMember(SignUpRequest signUpRequest, String url) {
         return Member.builder()
                 .email(signUpRequest.getEmail())
                 .nickName(signUpRequest.getSnsNickName())
-                .profileImageUrl(signUpRequest.getProfileImageUrl())
+                .profileImageUrl(url)
                 .providerType(signUpRequest.getProviderType())
                 .deviceToken(signUpRequest.getDeviceToken())
                 .isPushAgree((signUpRequest.getIsPushAgree()))

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -62,12 +62,12 @@ public class MemberService {
     }
 
     @Transactional
-    public SignUpResponse signUpAndRegisterProfile(SignUpRequest dto) {
+    public SignUpResponse signUpAndRegisterProfile(SignUpRequest dto, MultipartFile image) throws IOException {
         if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
             throw new DuplicateMemberException();
         }
-
-        Member signUpMember = Member.createNewMember(dto);
+        String profileImageUrl = s3FileUploader.upload(image, "test");
+        Member signUpMember = Member.createNewMember(dto, profileImageUrl);
 
         memberRepository.save(signUpMember);
 

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -17,8 +17,10 @@ import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -67,8 +69,9 @@ public class PetController {
     @PostMapping("/families/{familyId}/pet")
     public ResponseEntity<RegisterPetResponse> registerPet(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                            @RequestBody @Valid RegisterPetRequest dto,
-                                                           @PathVariable Long familyId) {
-        return ResponseEntity.ok(petService.registerPet(userDetails, dto, familyId));
+                                                           @RequestPart MultipartFile image,
+                                                           @PathVariable Long familyId) throws IOException {
+        return ResponseEntity.ok(petService.registerPet(userDetails, dto, familyId, image));
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -68,7 +68,7 @@ public class PetController {
     })
     @PostMapping("/families/{familyId}/pet")
     public ResponseEntity<RegisterPetResponse> registerPet(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                           @RequestBody @Valid RegisterPetRequest dto,
+                                                           @RequestPart @Valid RegisterPetRequest dto,
                                                            @RequestPart MultipartFile image,
                                                            @PathVariable Long familyId) throws IOException {
         return ResponseEntity.ok(petService.registerPet(userDetails, dto, familyId, image));

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/RegisterPetRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/RegisterPetRequest.java
@@ -16,8 +16,6 @@ public class RegisterPetRequest {
 
     private PetType petType;
 
-    private String profileImageUrl;
-
     private Gender gender;
 
     private LocalDate birthDate;

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -62,10 +62,10 @@ public class Pet extends BaseTimeEntity {
     @Builder.Default
     private List<CareLog> careLogList = new ArrayList<>();
 
-    public static Pet createPet(RegisterPetRequest dto) {
+    public static Pet createPet(RegisterPetRequest dto, String profileImageUrl) {
         return Pet.builder()
                 .petName(dto.getPetName())
-                .profileImageUrl(dto.getProfileImageUrl())
+                .profileImageUrl(profileImageUrl)
                 .birthDate(dto.getBirthDate())
                 .weight(dto.getWeight())
                 .registerNumber(dto.getRegisterNumber())

--- a/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3FileUploader.java
+++ b/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3FileUploader.java
@@ -25,6 +25,9 @@ public class S3FileUploader {
     private String bucket;
 
     public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        if (multipartFile.isEmpty()) {
+            return null;
+        }
         File uploadFile = convert(multipartFile)
                 .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
 

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -6,6 +6,8 @@ import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNic
 import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 
 public class MemberFactory {
 
@@ -17,7 +19,7 @@ public class MemberFactory {
                 .email("test@naver.com")
                 .nickName("test")
                 .profileImageUrl("abcdefghijk")
-                .type(ProviderType.KAKAO)
+                .providerType(ProviderType.KAKAO)
                 .deviceToken("abcdefg12345")
                 .build();
     }
@@ -53,10 +55,18 @@ public class MemberFactory {
                 .email("test@naver.com")
                 .snsNickName("test")
                 .deviceToken("abcde12345")
-                .profileImageUrl("S3URL")
                 .providerType(ProviderType.KAKAO)
                 .isPushAgree(Boolean.TRUE)
                 .isProfileInformationAgree(Boolean.TRUE)
                 .build();
+    }
+
+    public static MockMultipartFile createMultipartFile() {
+        return new MockMultipartFile(
+                "testfile",
+                "test.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "Hello, World!".getBytes()
+        );
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -19,13 +19,14 @@ class MemberTest {
         SignUpRequest signUpRequest = MemberFactory.createSignUpRequest();
 
         // when
-        Member newMember = Member.createNewMember(signUpRequest);
+        String imageUrl = "test";
+        Member newMember = Member.createNewMember(signUpRequest, imageUrl);
 
         // then
         assertThat(newMember.getId()).isNull();
         assertThat(newMember.getNickName()).isEqualTo(signUpRequest.getSnsNickName());
         assertThat(newMember.getEmail()).isEqualTo(signUpRequest.getEmail());
-        assertThat(newMember.getProfileImageUrl()).isEqualTo(signUpRequest.getProfileImageUrl());
+        assertThat(newMember.getProfileImageUrl()).isEqualTo(imageUrl);
         assertThat(newMember.getProviderType()).isEqualTo(signUpRequest.getProviderType());
         assertThat(newMember.getDeviceToken()).isEqualTo(signUpRequest.getDeviceToken());
 


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 클라이언트에서 이미지를 Mutlipart로 보내고, 서버에서 S3와 통신 후 저장된 접근 가능한 URL을 응답한다.
- Mutlipart가 null일 경우 imageURL null 저장 및 반환

## Test Checklist

- 

## To Client

- 회의 결과대로 진행
