### PR TITLE
Fix: 회원가입 시 Member field 초기화 수정

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -25,16 +25,16 @@ public class Member extends BaseTimeEntity {
     @Column(name = "memberId")
     private Long id;
 
-    // 개인정보 이용 약관
+    // 개인정보 이용 약관 (필수)
     private Boolean isPersonalInformationAgree;
 
-    // 서비스 이용 약관
+    // 서비스 이용 약관 (필수)
     private Boolean isToSAgree;
 
-    // 광고성 푸시알람 수신 동의
+    // 광고성 푸시알람 수신 동의 (선택)
     private Boolean isPushAgree;
 
-    // 프로필 정보 추가 수집 동의
+    // 프로필 정보 추가 수집 동의 (선택)
     private Boolean isProfileInformationAgree;
 
     @Enumerated(EnumType.STRING)
@@ -94,6 +94,11 @@ public class Member extends BaseTimeEntity {
                 .deviceToken(signUpRequest.getDeviceToken())
                 .isPushAgree((signUpRequest.getIsPushAgree()))
                 .isProfileInformationAgree(signUpRequest.getIsProfileInformationAgree())
+                .isPersonalInformationAgree(true)
+                .isToSAgree(true)
+                .accountStatus(AccountStatus.ACTIVE)
+                .familyRoleName("별명을 입력해주세요!")
+                .roleType(RoleType.MEMBER)
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -5,7 +5,9 @@ import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
+import org.retriever.server.dailypet.domain.member.enums.RoleType;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -21,6 +23,13 @@ public class MemberFactory {
                 .profileImageUrl("abcdefghijk")
                 .providerType(ProviderType.KAKAO)
                 .deviceToken("abcdefg12345")
+                .roleType(RoleType.MEMBER)
+                .isPushAgree(true)
+                .isProfileInformationAgree(true)
+                .isPersonalInformationAgree(true)
+                .isToSAgree(true)
+                .accountStatus(AccountStatus.ACTIVE)
+                .familyRoleName("별명을 입력해주세요!")
                 .build();
     }
 


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- Member Entity를 만드는 정적 팩토리 메서드인 createMember의 builder에 빠진 field 초기화 추가

## Test Checklist

- 

## To Client

- 
