### PR TITLE
Feat: 현재 회원의 가족 유무 조회 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyMemberRepository.java
@@ -3,6 +3,9 @@ package org.retriever.server.dailypet.domain.family.repository;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long> {
 
+    Optional<FamilyMember> findByMemberId(Long memberId);
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -92,6 +92,17 @@ public class MemberController {
         return ResponseEntity.ok(memberService.calculateDayOfFirstMeet(userDetails, petId));
     }
 
+    @Operation(summary = "가족 유무 조회", description = "해당 회원이 가족에 속해있는지 유무 반환")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "가족 정상 조회"),
+            @ApiResponse(responseCode = "400", description = "가족에 속해 있지 않음"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/members/{memberId}/family")
+    public ResponseEntity<Void> checkGroup(@PathVariable Long memberId) {
+        memberService.checkGroup(memberId);
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/test")
     public String test() {

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -1,19 +1,21 @@
 package org.retriever.server.dailypet.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyMemberRepository;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
+import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.CalculateDayResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.EditProfileImageResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
+import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.member.exception.DifferentProviderTypeException;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberException;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberNicknameException;
-import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundException;
-import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
-import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
+import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.pet.exception.PetNotFoundException;
 import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
@@ -26,8 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.Period;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +38,7 @@ public class MemberService {
     private final PetRepository petRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final S3FileUploader s3FileUploader;
+    private final FamilyMemberRepository familyMemberRepository;
 
     public SnsLoginResponse checkMemberAndLogin(SnsLoginRequest dto) {
         Member member = memberRepository.findByEmail(dto.getEmail())
@@ -95,5 +96,10 @@ public class MemberService {
         int calculatedDay = LocalDateTimeUtils.calculateDaysFromNow(pet.getBirthDate());
 
         return CalculateDayResponse.of(member.getNickName(), pet.getPetName(), calculatedDay);
+    }
+
+    public void checkGroup(Long memberId) {
+        memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        familyMemberRepository.findByMemberId(memberId).orElseThrow(FamilyNotFoundException::new);
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/security/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .authorizeRequests()
                     .antMatchers(HttpMethod.POST, "/api/v1/auth/login",
                             "/api/v1/validation/nickname", "/api/v1/auth/sign-up").permitAll()
-                    .antMatchers(HttpMethod.GET, "/api/v1/test").permitAll()
+                    .antMatchers(HttpMethod.GET, "/api/v1/test",
+                            "/api/v1/members/{memberId}/family").permitAll()
                     .anyRequest().authenticated();
     }
 


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 현재 memberId를 통해서 가족 유무 조회 API
- SecurityConfig GET에 path 추가

## Test Checklist

- 

## To Client

- 프로필 등록 -> 그룹 등록 -> 반려동물 등록 step 중 프로필 등록만 하고 종료한 케이스에 사용합니다.
- 해당 회원 ID가 유효하지 않은 경우, 혹은 해당 회원이 가족이 존재하지 않은 경우를 검증합니다.
- 일단 서버는 네이밍을 기존대로 family로 진행하겠습니다.
