### PR TITLE
Feat: 계정 등록 진행 상태 API, 테스트 수정, 클라이언트 요구사항 수정

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -10,6 +10,7 @@ import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyReque
 import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
 import org.springframework.http.ResponseEntity;
@@ -60,9 +61,8 @@ public class FamilyController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/family")
-    public ResponseEntity<Void> createFamily(@RequestBody @Valid CreateFamilyRequest dto) throws IOException {
-        familyService.createFamily(dto);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<CreateFamilyResponse> createFamily(@RequestPart @Valid CreateFamilyRequest dto) throws IOException {
+        return ResponseEntity.ok(familyService.createFamily(dto));
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)

--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -10,7 +10,6 @@ import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyReque
 import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
-import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
 import org.springframework.http.ResponseEntity;
@@ -61,8 +60,9 @@ public class FamilyController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/family")
-    public ResponseEntity<CreateFamilyResponse> createFamily(@RequestPart @Valid CreateFamilyRequest dto) throws IOException {
-        return ResponseEntity.ok(familyService.createFamily(dto));
+    public ResponseEntity<Void> createFamily(@RequestBody @Valid CreateFamilyRequest dto) throws IOException {
+        familyService.createFamily(dto);
+        return ResponseEntity.ok().build();
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/AccountProgressStatusResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/AccountProgressStatusResponse.java
@@ -1,0 +1,13 @@
+package org.retriever.server.dailypet.domain.family.dto.response;
+
+import lombok.*;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class AccountProgressStatusResponse {
+
+    private AccountProgressStatus status;
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/CreateFamilyResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/CreateFamilyResponse.java
@@ -8,7 +8,5 @@ import lombok.*;
 @Getter
 public class CreateFamilyResponse {
 
-    private String familyName;
-
-    private String invitationCode;
+    private Long familyId;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -48,7 +48,7 @@ public class FamilyService {
     }
 
     @Transactional
-    public CreateFamilyResponse createFamily(CreateFamilyRequest dto) throws IOException {
+    public void createFamily(CreateFamilyRequest dto) throws IOException {
 
         // 멤버 조회 및 권한 지정
         Member member = securityUtil.getMemberByUserDetails();
@@ -63,11 +63,6 @@ public class FamilyService {
         // 연관관계 편의 메서드 - family.familyMemberList에 add & cascade.All 옵션을 통해 familyMember 자동 persist
         newFamily.insertNewMember(familyMember);
         familyRepository.save(newFamily);
-
-        return CreateFamilyResponse.builder()
-                .familyName(newFamily.getFamilyName())
-                .invitationCode(invitationCode)
-                .build();
     }
 
     public FindFamilyWithInvitationCodeResponse findFamilyWithInvitationCode(String code) {

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -48,7 +48,7 @@ public class FamilyService {
     }
 
     @Transactional
-    public void createFamily(CreateFamilyRequest dto) throws IOException {
+    public CreateFamilyResponse createFamily(CreateFamilyRequest dto) throws IOException {
 
         // 멤버 조회 및 권한 지정
         Member member = securityUtil.getMemberByUserDetails();
@@ -63,6 +63,10 @@ public class FamilyService {
         // 연관관계 편의 메서드 - family.familyMemberList에 add & cascade.All 옵션을 통해 familyMember 자동 persist
         newFamily.insertNewMember(familyMember);
         familyRepository.save(newFamily);
+
+        return CreateFamilyResponse.builder()
+                .familyId(newFamily.getFamilyId())
+                .build();
     }
 
     public FindFamilyWithInvitationCodeResponse findFamilyWithInvitationCode(String code) {

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -54,6 +54,7 @@ public class FamilyService {
         Member member = securityUtil.getMemberByUserDetails();
         member.setFamilyLeader();
         member.changeFamilyRoleName(dto.getFamilyRoleName());
+        member.changeProgressStatusToGroup();
 
         // 새로운 가족 그룹 생성 - 초대코드 생성
         String invitationCode = InvitationCodeUtil.createInvitationCode();

--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/LoginController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/LoginController.java
@@ -1,0 +1,38 @@
+package org.retriever.server.dailypet.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.dto.response.AccountProgressStatusResponse;
+import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
+import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
+import org.retriever.server.dailypet.domain.member.service.LoginService;
+import org.retriever.server.dailypet.domain.member.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Login API")
+public class LoginController {
+
+    private final LoginService loginService;
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "서비스 등록 진행 상황 조회", description = "어느 단계까지 진행했는지 조회한다. PROFILE(0), GROUP(1), PET(2)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "단계 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "단계 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/progress-status")
+    public ResponseEntity<AccountProgressStatusResponse> checkProgressStatus() {
+        return ResponseEntity.ok(loginService.checkProgressStatus());
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package org.retriever.server.dailypet.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -63,6 +64,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto, image));
     }
 
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "회원 프로필 사진 수정", description = "회원의 프로필 사진을 수정한다")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원 프로필 사진 정상 수정"),
@@ -75,6 +77,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.editProfileImage(image));
     }
 
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "메인 페이지 - 반려동물과 보낸 시간 조회", description = "나와 반려동물이 만난지 얼마나 됐는지 날짜를 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "정상 조회"),
@@ -86,6 +89,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.calculateDayOfFirstMeet(petId));
     }
 
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "가족 유무 조회", description = "해당 회원이 가족에 속해있는지 유무 반환")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "가족 정상 조회"),
@@ -97,6 +101,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.checkGroup());
     }
 
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "반려동물 유무 조회", description = "해당 회원의 가족이 반려동물을 등록했는지 유무 반환")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "반려동물 정상 조회"),
@@ -108,6 +113,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.checkPet(familyId));
     }
 
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원 탈퇴 정상 처리"),
@@ -118,10 +124,5 @@ public class MemberController {
     public ResponseEntity<Void> deleteMember() {
         memberService.deleteMember();
         return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/test")
-    public String test() {
-        return "hello it's test";
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
@@ -59,6 +60,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private RoleType roleType;
 
+    @Enumerated(EnumType.STRING)
+    private AccountProgressStatus accountProgressStatus;
+
     private String deviceToken;
 
     private String password;
@@ -85,6 +89,7 @@ public class Member extends BaseTimeEntity {
         this.providerType = type;
         this.roleType = RoleType.MEMBER;
         this.deviceToken = deviceToken;
+        this.accountProgressStatus = AccountProgressStatus.PROFILE;
     }
 
     public static Member createNewMember(SignUpRequest signUpRequest, String url) {
@@ -101,6 +106,7 @@ public class Member extends BaseTimeEntity {
                 .accountStatus(AccountStatus.ACTIVE)
                 .familyRoleName("별명을 입력해주세요!")
                 .roleType(RoleType.MEMBER)
+                .accountProgressStatus(AccountProgressStatus.PROFILE)
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -125,4 +125,12 @@ public class Member extends BaseTimeEntity {
     public void deleteMember() {
         this.accountStatus = AccountStatus.DELETED;
     }
+
+    public void changeProgressStatusToGroup() {
+        this.accountProgressStatus = AccountProgressStatus.GROUP;
+    }
+
+    public void changeProgressStatusToPet() {
+        this.accountProgressStatus = AccountProgressStatus.PET;
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/enums/AccountProgressStatus.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/enums/AccountProgressStatus.java
@@ -1,0 +1,5 @@
+package org.retriever.server.dailypet.domain.member.enums;
+
+public enum AccountProgressStatus {
+    PROFILE, GROUP, PET
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/LoginService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/LoginService.java
@@ -1,0 +1,22 @@
+package org.retriever.server.dailypet.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.dto.response.AccountProgressStatusResponse;
+import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoginService {
+
+    private final SecurityUtil securityUtil;
+
+    public AccountProgressStatusResponse checkProgressStatus() {
+        return AccountProgressStatusResponse.builder()
+                .status(securityUtil.getMemberByUserDetails()
+                        .getAccountProgressStatus())
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/RegisterPetResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/RegisterPetResponse.java
@@ -21,8 +21,6 @@ public class RegisterPetResponse {
 
     private List<PetInfoResponse> petList;
 
-    private int petCount;
-
     private String invitationCode;
 
     public static RegisterPetResponse from(Member member, Family family) {
@@ -33,7 +31,6 @@ public class RegisterPetResponse {
                 .petList(family.getPetList().stream()
                         .map(PetInfoResponse::new)
                         .collect(Collectors.toList()))
-                .petCount(family.getPetList().size())
                 .invitationCode(family.getInvitationCode())
                 .build();
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
@@ -67,6 +67,7 @@ public class PetService {
     public RegisterPetResponse registerPet(RegisterPetRequest dto, Long familyId, MultipartFile image) throws IOException {
 
         Member member = securityUtil.getMemberByUserDetails();
+        member.changeProgressStatusToPet();
         Family family = familyRepository.findById(familyId).orElseThrow(FamilyNotFoundException::new);
         PetKind petKind = petKindRepository.findByPetKindId(dto.getPetKindId()).orElseThrow(PetTypeNotFoundException::new);
         String profileImageUrl = s3FileUploader.upload(image, "test");

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
@@ -56,8 +56,7 @@ public class FamilyFactory {
 
     public static CreateFamilyResponse createFamilyResponse() {
         return CreateFamilyResponse.builder()
-                .familyName("testFamily")
-                .invitationCode("1234567890")
+                .familyId(1L)
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -6,6 +6,7 @@ import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
@@ -36,6 +37,7 @@ public class MemberFactory {
                 .isPersonalInformationAgree(true)
                 .isToSAgree(true)
                 .accountStatus(AccountStatus.ACTIVE)
+                .accountProgressStatus(AccountProgressStatus.PROFILE)
                 .familyRoleName("별명을 입력해주세요!")
                 .build();
     }
@@ -53,6 +55,7 @@ public class MemberFactory {
                 .isPersonalInformationAgree(true)
                 .isToSAgree(true)
                 .accountStatus(AccountStatus.ACTIVE)
+                .accountProgressStatus(AccountProgressStatus.GROUP)
                 .familyRoleName("별명을 입력해주세요!")
                 .familyMemberList(new ArrayList<>(List.of(
                         FamilyMember.builder().member(Member.builder().familyRoleName(name1).build()).build(),

--- a/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
@@ -12,7 +12,6 @@ import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyReque
 import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
-import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
@@ -120,13 +119,11 @@ class FamilyServiceTest {
         when(securityUtil.getMemberByUserDetails()).thenReturn(member);
 
         // when
-        CreateFamilyResponse response = familyService.createFamily(familyRequest);
+        familyService.createFamily(familyRequest);
 
         // then
         assertThat(member.getFamilyRoleName()).isEqualTo(familyRequest.getFamilyRoleName());
         assertThat(member.getRoleType()).isEqualTo(RoleType.FAMILY_LEADER);
-        assertThat(response.getFamilyName()).isEqualTo(familyRequest.getFamilyName());
-        assertThat(response.getInvitationCode()).isNotNull();
         assertAll(
                 () -> verify(securityUtil, times(1)).getMemberByUserDetails(),
                 () -> verify(familyRepository, times(1)).save(any())

--- a/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
@@ -20,6 +20,7 @@ import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyRole
 import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
 import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
@@ -125,6 +126,7 @@ class FamilyServiceTest {
         // then
         assertThat(member.getFamilyRoleName()).isEqualTo(familyRequest.getFamilyRoleName());
         assertThat(member.getRoleType()).isEqualTo(RoleType.FAMILY_LEADER);
+        assertThat(member.getAccountProgressStatus()).isEqualTo(AccountProgressStatus.GROUP);
         assertAll(
                 () -> verify(securityUtil, times(1)).getMemberByUserDetails(),
                 () -> verify(familyRepository, times(1)).save(any())

--- a/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
@@ -12,6 +12,7 @@ import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyReque
 import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
+import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
@@ -119,7 +120,7 @@ class FamilyServiceTest {
         when(securityUtil.getMemberByUserDetails()).thenReturn(member);
 
         // when
-        familyService.createFamily(familyRequest);
+        CreateFamilyResponse response = familyService.createFamily(familyRequest);
 
         // then
         assertThat(member.getFamilyRoleName()).isEqualTo(familyRequest.getFamilyRoleName());

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
 
@@ -32,6 +33,7 @@ class MemberTest {
 
         assertThat(newMember.getAccountStatus()).isEqualTo(AccountStatus.ACTIVE);
         assertThat(newMember.getRoleType()).isEqualTo(RoleType.MEMBER);
+        assertThat(newMember.getAccountProgressStatus()).isEqualTo(AccountProgressStatus.PROFILE);
         assertThat(newMember.getIsPersonalInformationAgree()).isTrue();
         assertThat(newMember.getIsToSAgree()).isTrue();
         assertThat(newMember.getIsPushAgree()).isTrue();
@@ -67,5 +69,33 @@ class MemberTest {
 
         // then
         assertThat(testMember.getAccountStatus()).isEqualTo(AccountStatus.DELETED);
+    }
+
+    @DisplayName("계정 진행 상태 GROUP으로 변경")
+    @Test
+    void change_status_to_group() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+
+        // when
+        testMember.changeProgressStatusToGroup();
+
+        // then
+        assertThat(testMember.getAccountProgressStatus()).isEqualTo(AccountProgressStatus.GROUP);
+    }
+
+    @DisplayName("계정 진행 상태 PET으로 변경")
+    @Test
+    void change_status_to_pet() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+
+        // when
+        testMember.changeProgressStatusToPet();
+
+        // then
+        assertThat(testMember.getAccountProgressStatus()).isEqualTo(AccountProgressStatus.PET);
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/LoginServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/LoginServiceTest.java
@@ -1,0 +1,73 @@
+package org.retriever.server.dailypet.domain.member.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.family.dto.response.AccountProgressStatusResponse;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
+import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @Mock
+    SecurityUtil securityUtil;
+
+    @InjectMocks
+    LoginService loginService;
+
+    @Test
+    @DisplayName("프로필 등록 후 이탈한 회원 조회")
+    void get_progress_status_profile() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+
+        // when
+        AccountProgressStatusResponse response = loginService.checkProgressStatus();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(AccountProgressStatus.PROFILE);
+    }
+
+    @Test
+    @DisplayName("그룹 등록 후 이탈한 회원 조회")
+    void get_progress_status_group() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        testMember.changeProgressStatusToGroup();
+
+        // when
+        AccountProgressStatusResponse response = loginService.checkProgressStatus();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(AccountProgressStatus.GROUP);
+    }
+
+    @Test
+    @DisplayName("반려동물 등록까지 완료한 회원 조회")
+    void get_progress_status_pet() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        testMember.changeProgressStatusToPet();
+
+        // when
+        AccountProgressStatusResponse response = loginService.checkProgressStatus();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(AccountProgressStatus.PET);
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
@@ -12,6 +12,7 @@ import org.retriever.server.dailypet.domain.common.factory.PetFactory;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
@@ -118,7 +119,7 @@ class PetServiceTest {
         PetKind petKind = PetFactory.createTestPetKind();
         RegisterPetRequest request = PetFactory.createRegisterPetRequest();
         String imageUrl = "testUrl";
-        int beforeSize = family.getPetList().size();
+
         given(familyRepository.findById(any())).willReturn(Optional.of(family));
         given(s3FileUploader.upload(any(), any())).willReturn(imageUrl);
         given(petKindRepository.findByPetKindId(any())).willReturn(Optional.of(petKind));
@@ -136,6 +137,7 @@ class PetServiceTest {
         assertThat(response.getPetList()).isNotNull();
         assertThat(response.getPetList().get(0).getPetName()).isEqualTo(request.getPetName());
         assertThat(family.getPetList()).isNotNull();
+        assertThat(member.getAccountProgressStatus()).isEqualTo(AccountProgressStatus.PET);
     }
 
     @DisplayName("메인 페이지 - 반려동물 챙겨주기 탭 조회 성공")

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
@@ -131,7 +131,6 @@ class PetServiceTest {
         verify(petRepository, times(1)).save(any());
         assertThat(response.getFamilyId()).isEqualTo(family.getFamilyId());
         assertThat(response.getFamilyName()).isEqualTo(family.getFamilyName());
-        assertThat(response.getPetCount()).isEqualTo(beforeSize + 1);
         assertThat(response.getFamilyRoleName()).isEqualTo(member.getFamilyRoleName());
         assertThat(response.getInvitationCode()).isEqualTo(family.getInvitationCode());
         assertThat(response.getPetList()).isNotNull();


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 계정 등록 진행 상태 필드 추가
- 진행 상태 조회 get API 추가
- 그룹 등록 시 진행 상태 GROUP으로 변경
- 펫 등록 시 진행 상태 PET으로 변경
- 해당 단위 테스트 추가
- ReqeuestPart -> RequestBody로 수정
- 그룹 생성 시 응답 familyId 반환
- 펫 등록 시 응답 petCount 필드 제거

## Test Checklist

- [x] todo

## To Client

1. 그룹 등록 시 familyId 반환
2. 그룹 등록 시 request dto 제거
3. 펫 등록 시 응답 petCount 제거
4. 계정 진행 상태 조회 api 추가
5. 그룹, 펫 등록 시 진행 상태 자동 변경
6. swagger jwt token required 추가
