### PR TITLE
Refactor: current care count 계산 로직 수정, test 코드 추가

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/GetPetCaresDetailResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/GetPetCaresDetailResponse.java
@@ -23,7 +23,7 @@ public class GetPetCaresDetailResponse {
     public static GetPetCaresDetailResponse of(PetCare petCare, List<CareLogHistory> list) {
         return GetPetCaresDetailResponse.builder()
                 .careName(petCare.getCareName())
-                .currentCount(petCare.getCurrentCount())
+                .currentCount(list.size())
                 .totalCountPerDay(petCare.getTotalCountPerDay())
                 .logHistoryList(list)
                 .build();

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/controller/PetCareController.java
@@ -56,7 +56,7 @@ public class PetCareController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/pets/{petId}/cares/{careId}/cancel")
-    public ResponseEntity<CancelPetCareResponse> cancelPetCare(@PathVariable Long petId, @PathVariable Long careId) {
-        return ResponseEntity.ok(petCareService.cancelPetCare(petId, careId));
+    public ResponseEntity<CancelPetCareResponse> cancelPetCare(@PathVariable Long careId) {
+        return ResponseEntity.ok(petCareService.cancelPetCare(careId));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
@@ -25,8 +25,6 @@ public class PetCare extends BaseTimeEntity {
 
     private String careName;
 
-    private int currentCount;
-
     private int totalCountPerDay;
 
     private Boolean isPushAgree;
@@ -64,19 +62,19 @@ public class PetCare extends BaseTimeEntity {
         petCareAlarm.setPetCare(this);
     }
 
-    public void pushCareCheckButton() {
-        int after = this.currentCount + 1;
+    public int pushCareCheckButton(int currentCount) {
+        int after = currentCount + 1;
         if (after > totalCountPerDay) {
             throw new CareCountExceededException();
         }
-        this.currentCount = after;
+        return after;
     }
 
-    public void cancelCareCheckButton() {
-        int after = this.currentCount - 1;
+    public int cancelCareCheckButton(int currentCount) {
+        int after = currentCount - 1;
         if (after < 0) {
             throw new CareCountIsZeroException();
         }
-        this.currentCount = after;
+        return after;
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/repository/CareLogQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/repository/CareLogQueryRepository.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -38,5 +37,16 @@ public class CareLogQueryRepository {
                 .setParameter("petCareId", petCareId)
                 .setMaxResults(1)
                 .getSingleResult();
+    }
+
+    // 오늘 해당 챙겨주기 항목에 대한 횟수 조회 쿼리
+    public int findTodayCountByCareId(Long petCareId) {
+        return entityManager.createQuery("select c from CareLog c" +
+                        " where" +
+                        " c.petCare.petCareId = :petCareId" +
+                        " and" +
+                        " c.logDate = current_date", CareLog.class)
+                .setParameter("petCareId", petCareId)
+                .getResultList().size();
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/CareLogFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/CareLogFactory.java
@@ -1,0 +1,20 @@
+package org.retriever.server.dailypet.domain.common.factory;
+
+import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
+import org.retriever.server.dailypet.domain.petcare.enums.CareLogStatus;
+
+import java.time.LocalDate;
+
+public class CareLogFactory {
+
+    private CareLogFactory() {
+
+    }
+
+    public static CareLog createTestCareLog() {
+        return CareLog.builder()
+                .logDate(LocalDate.now())
+                .careLogStatus(CareLogStatus.CHECK)
+                .build();
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetCareFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetCareFactory.java
@@ -1,0 +1,28 @@
+package org.retriever.server.dailypet.domain.common.factory;
+
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
+import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
+
+import java.util.List;
+
+public class PetCareFactory {
+
+    private PetCareFactory() {
+    }
+
+    public static PetCare createTestPetCare() {
+        return PetCare.builder()
+                .careName("testCare")
+                .totalCountPerDay(5)
+                .build();
+    }
+
+    public static CreatePetCareRequest createPetCareRequest() {
+        return CreatePetCareRequest.builder()
+                .careName("testCare")
+                .totalCountPerDay(5)
+                .dayOfWeeks(List.of(CustomDayOfWeek.MON))
+                .build();
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareTest.java
@@ -1,0 +1,82 @@
+package org.retriever.server.dailypet.domain.petcare.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.retriever.server.dailypet.domain.common.factory.PetCareFactory;
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.enums.PetCareStatus;
+import org.retriever.server.dailypet.domain.petcare.exception.CareCountExceededException;
+import org.retriever.server.dailypet.domain.petcare.exception.CareCountIsZeroException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PetCareTest {
+
+    @Test
+    @DisplayName("챙겨주기 등록 요청을 받아 생성한다")
+    void create_care() {
+
+        //given
+        CreatePetCareRequest petCareRequest = PetCareFactory.createPetCareRequest();
+
+        // when
+        PetCare petCare = PetCare.from(petCareRequest);
+
+        // then
+        assertThat(petCare.getCareName()).isEqualTo(petCareRequest.getCareName());
+        assertThat(petCare.getTotalCountPerDay()).isEqualTo(petCareRequest.getTotalCountPerDay());
+        assertThat(petCare.getIsPushAgree()).isEqualTo(Boolean.FALSE);
+        assertThat(petCare.getPetCareStatus()).isEqualTo(PetCareStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 체크 시 1회 증가한다")
+    void check_care_success() {
+        // given
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        int beforeCount = 3;
+
+        // when
+        int afterCount = testPetCare.pushCareCheckButton(beforeCount);
+
+        // then
+        assertThat(beforeCount + 1).isEqualTo(afterCount);
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 취소 시 1회 감소한다.")
+    void cancel_care_success() {
+        // given
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        int beforeCount = 3;
+
+        // when
+        int afterCount = testPetCare.cancelCareCheckButton(beforeCount);
+
+        // then
+        assertThat(beforeCount - 1).isEqualTo(afterCount);
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 체크 실패 - 일일 할당량 초과")
+    void check_care_fail() {
+        // given
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        int beforeCount = testPetCare.getTotalCountPerDay();
+
+        // when, then
+        assertThrows(CareCountExceededException.class, () -> testPetCare.pushCareCheckButton(beforeCount));
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 취소 실패 - 0회")
+    void cancel_care_fail() {
+        // given
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        int beforeCount = 0;
+
+        // when, then
+        assertThrows(CareCountIsZeroException.class, () -> testPetCare.cancelCareCheckButton(beforeCount));
+    }
+}

--- a/src/test/java/org/retriever/server/dailypet/domain/petcare/service/PetCareServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/petcare/service/PetCareServiceTest.java
@@ -1,0 +1,175 @@
+package org.retriever.server.dailypet.domain.petcare.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.retriever.server.dailypet.domain.common.factory.CareLogFactory;
+import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.common.factory.PetCareFactory;
+import org.retriever.server.dailypet.domain.common.factory.PetFactory;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
+import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.petcare.dto.response.CancelPetCareResponse;
+import org.retriever.server.dailypet.domain.petcare.dto.response.CheckPetCareResponse;
+import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
+import org.retriever.server.dailypet.domain.petcare.enums.CareLogStatus;
+import org.retriever.server.dailypet.domain.petcare.exception.CareCountExceededException;
+import org.retriever.server.dailypet.domain.petcare.exception.CareCountIsZeroException;
+import org.retriever.server.dailypet.domain.petcare.exception.NotCancelCareLogException;
+import org.retriever.server.dailypet.domain.petcare.repository.CareLogQueryRepository;
+import org.retriever.server.dailypet.domain.petcare.repository.CareLogRepository;
+import org.retriever.server.dailypet.domain.petcare.repository.PetCareRepository;
+import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PetCareServiceTest {
+
+    @Mock
+    PetRepository petRepository;
+    @Mock
+    PetCareRepository petCareRepository;
+    @Mock
+    CareLogRepository careLogRepository;
+    @Mock
+    CareLogQueryRepository careLogQueryRepository;
+    @Mock
+    SecurityUtil securityUtil;
+    @InjectMocks
+    PetCareService petCareService;
+
+    @Test
+    @DisplayName("챙겨주기 등록 요청을 받아 생성한다")
+    void register_care_success() {
+
+        // given
+        Pet testPet = PetFactory.createTestPet();
+        CreatePetCareRequest petCareRequest = PetCareFactory.createPetCareRequest();
+        given(petRepository.findById(any())).willReturn(Optional.of(testPet));
+
+        // when
+        petCareService.registerPetCare(testPet.getPetId(), petCareRequest);
+
+        // then
+        Assertions.assertAll(
+                () -> verify(petCareRepository, times(1)).save(any())
+        );
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 등록 성공")
+    void check_care_success() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        Pet testPet = PetFactory.createTestPet();
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        int beforeCount = 3;
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        given(petRepository.findById(any())).willReturn(Optional.of(testPet));
+        given(petCareRepository.findById(any())).willReturn(Optional.of(testPetCare));
+        given(careLogQueryRepository.findTodayCountByCareId(any())).willReturn(beforeCount);
+
+        // when
+        CheckPetCareResponse checkPetCareResponse = petCareService.checkPetCare(testPet.getPetId(), testPetCare.getPetCareId());
+
+        // then
+        Assertions.assertAll(
+                () -> verify(careLogRepository, times(1)).save(any()),
+                () -> verify(careLogQueryRepository, times(1)).findTodayCountByCareId(any()),
+                () -> assertEquals(checkPetCareResponse.getCurrentCount(), beforeCount+1),
+                () -> assertEquals(checkPetCareResponse.getMemberNameWhoChecked(), testMember.getFamilyRoleName()),
+                () -> assertEquals(checkPetCareResponse.getPetCareId(), testPetCare.getPetCareId())
+        );
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 등록 실패 - 일일 할당량 초과")
+    void check_care_fail() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        Pet testPet = PetFactory.createTestPet();
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        int beforeCount = testPetCare.getTotalCountPerDay();
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        given(petRepository.findById(any())).willReturn(Optional.of(testPet));
+        given(petCareRepository.findById(any())).willReturn(Optional.of(testPetCare));
+        given(careLogQueryRepository.findTodayCountByCareId(any())).willReturn(beforeCount);
+
+        // when, then
+        assertThrows(CareCountExceededException.class, () -> petCareService.checkPetCare(testPet.getPetId(), testPetCare.getPetCareId()));
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 취소 성공")
+    void cancel_care_success() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        CareLog testCareLog = CareLogFactory.createTestCareLog();
+        int beforeCount = 3;
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        given(petCareRepository.findById(any())).willReturn(Optional.of(testPetCare));
+        given(careLogQueryRepository.findByMemberIdAndCareIdWithCurDateLatestLimit1(any(), any())).willReturn(testCareLog);
+        given(careLogQueryRepository.findTodayCountByCareId(any())).willReturn(beforeCount);
+
+        // when
+        CancelPetCareResponse cancelPetCareResponse = petCareService.cancelPetCare(testPetCare.getPetCareId());
+
+        // then
+        Assertions.assertAll(
+                () -> verify(careLogQueryRepository, times(1)).findByMemberIdAndCareIdWithCurDateLatestLimit1(any(), any()),
+                () -> verify(careLogQueryRepository, times(1)).findTodayCountByCareId(any()),
+                () -> assertEquals(cancelPetCareResponse.getCurrentCount(), beforeCount - 1),
+                () -> assertEquals(testCareLog.getCareLogStatus(), CareLogStatus.CANCEL)
+        );
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 취소 실패 - 현재 횟수가 0인 경우")
+    void cancel_care_fail_current_count_is_zero() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        CareLog testCareLog = CareLogFactory.createTestCareLog();
+        int beforeCount = 0;
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        given(petCareRepository.findById(any())).willReturn(Optional.of(testPetCare));
+        given(careLogQueryRepository.findByMemberIdAndCareIdWithCurDateLatestLimit1(any(), any())).willReturn(testCareLog);
+        given(careLogQueryRepository.findTodayCountByCareId(any())).willReturn(beforeCount);
+
+        // when, then
+        assertThrows(CareCountIsZeroException.class, () -> petCareService.cancelPetCare(testPetCare.getPetCareId()));
+    }
+
+    @Test
+    @DisplayName("챙겨주기 1회 취소 실패 - 내가 한 행동만 취소가 가능 (오늘 한 일이 없는 경우)")
+    void cancel_care_fail_my_count_is_zero() {
+
+        // given
+        Member testMember = MemberFactory.createTestMember();
+        PetCare testPetCare = PetCareFactory.createTestPetCare();
+        given(securityUtil.getMemberByUserDetails()).willReturn(testMember);
+        given(petCareRepository.findById(any())).willReturn(Optional.of(testPetCare));
+        given(careLogQueryRepository.findByMemberIdAndCareIdWithCurDateLatestLimit1(any(), any())).willReturn(null);
+
+        // when, then
+        assertThrows(NotCancelCareLogException.class, () -> petCareService.cancelPetCare(testPetCare.getPetCareId()));
+    }
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/38
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- DB에 currentCount field를 저장하는 것이 아닌, CareLog에서 CountQuery를 통해서 조회한다.
- 이렇게 되면, 매일 정각에 currentCount field를 초기화할 필요가 없어짐

## Test Checklist

- [ ] 테스트 추가

## To Client

- 어제 멘토링 내용 변경사항입니다.
