### PR TITLE
Feat: 회원 탈퇴 & 관련 객체 Soft Delete 진행

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
@@ -34,7 +34,7 @@ public class Family extends BaseTimeEntity {
     @Column(nullable = false, unique = true, length = 10)
     private String invitationCode;
 
-    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "family", cascade = CascadeType.PERSIST)
     @Builder.Default
     private List<FamilyMember> familyMemberList = new ArrayList<>();
 

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
@@ -1,6 +1,8 @@
 package org.retriever.server.dailypet.domain.family.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
@@ -15,6 +17,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Where(clause = "family_status = 'ACTIVE'")
+@SQLDelete(sql = "UPDATE family SET family_status = 'DELETED' WHERE family_id = ?")
 public class Family extends BaseTimeEntity {
 
     @Id
@@ -34,7 +38,7 @@ public class Family extends BaseTimeEntity {
     @Builder.Default
     private List<FamilyMember> familyMemberList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "family")
+    @OneToMany(mappedBy = "family", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<Pet> petList = new ArrayList<>();
 

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/FamilyMember.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/FamilyMember.java
@@ -1,8 +1,11 @@
 package org.retriever.server.dailypet.domain.family.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.model.IsDeleted;
 
 import javax.persistence.*;
 
@@ -11,6 +14,8 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Where(clause = "is_deleted = 'FALSE'")
+@SQLDelete(sql = "UPDATE family_member SET is_deleted = 'TRUE' WHERE family_member_id = ?")
 public class FamilyMember extends BaseTimeEntity {
 
     @Id
@@ -25,10 +30,14 @@ public class FamilyMember extends BaseTimeEntity {
     @JoinColumn(name = "familyId", nullable = false)
     private Family family;
 
+    @Enumerated(EnumType.STRING)
+    private IsDeleted isDeleted;
+
     public static FamilyMember createFamilyMember(Member member, Family family) {
         return FamilyMember.builder()
                 .member(member)
                 .family(family)
+                .isDeleted(IsDeleted.FALSE)
                 .build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -1,14 +1,15 @@
 package org.retriever.server.dailypet.domain.member.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
-import org.retriever.server.dailypet.domain.member.enums.RoleType;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
-import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
+import org.retriever.server.dailypet.domain.member.enums.RoleType;
+import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
 
 import javax.persistence.*;
@@ -21,6 +22,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Where(clause = "account_status = 'ACTIVE'")
+@SQLDelete(sql = "UPDATE member SET account_status = 'DELETED' WHERE member_id = ?")
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -67,11 +69,11 @@ public class Member extends BaseTimeEntity {
 
     private String password;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<FamilyMember> familyMemberList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<CareLog> careLogList = new ArrayList<>();
 
@@ -123,6 +125,10 @@ public class Member extends BaseTimeEntity {
     }
 
     public void deleteMember() {
+        // TODO : 리더일 경우 따로 처리
+        if (this.roleType == RoleType.FAMILY_LEADER) {
+
+        }
         this.accountStatus = AccountStatus.DELETED;
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -1,8 +1,10 @@
 package org.retriever.server.dailypet.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
@@ -35,6 +37,7 @@ import java.util.List;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final FamilyRepository familyRepository;
     private final PetRepository petRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final S3FileUploader s3FileUploader;
@@ -140,6 +143,13 @@ public class MemberService {
     @Transactional
     public void deleteMember() {
         Member member = securityUtil.getMemberByUserDetails();
-        member.deleteMember();
+        Family family = null;
+        List<FamilyMember> familyByMemberId = memberQueryRepository.findFamilyByMemberId(member.getId());
+        if (!familyByMemberId.isEmpty()) {
+            family = familyByMemberId.get(0).getFamily();
+        }
+        memberRepository.delete(member);
+        if(family != null)
+            familyRepository.delete(family);
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/model/IsDeleted.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/model/IsDeleted.java
@@ -1,0 +1,5 @@
+package org.retriever.server.dailypet.domain.model;
+
+public enum IsDeleted {
+    TRUE, FALSE
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -1,6 +1,8 @@
 package org.retriever.server.dailypet.domain.pet.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
@@ -19,6 +21,8 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Where(clause = "pet_status = 'ACTIVE'")
+@SQLDelete(sql = "UPDATE pet SET pet_status = 'DELETED' WHERE pet_id = ?")
 public class Pet extends BaseTimeEntity {
 
     @Id
@@ -44,7 +48,7 @@ public class Pet extends BaseTimeEntity {
     private Gender gender;
 
     @Enumerated(EnumType.STRING)
-    private PetStatus status;
+    private PetStatus petStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petKindId", nullable = false)
@@ -54,7 +58,7 @@ public class Pet extends BaseTimeEntity {
     @JoinColumn(name = "familyId", nullable = false)
     private Family family;
 
-    @OneToMany(mappedBy = "pet")
+    @OneToMany(mappedBy = "pet", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<PetCare> petCareList = new ArrayList<>();
 
@@ -71,7 +75,7 @@ public class Pet extends BaseTimeEntity {
                 .registerNumber(dto.getRegisterNumber())
                 .isNeutered(dto.getIsNeutered())
                 .gender(dto.getGender())
-                .status(PetStatus.ACTIVE)
+                .petStatus(PetStatus.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
@@ -1,8 +1,11 @@
 package org.retriever.server.dailypet.domain.petcare.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.model.IsDeleted;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.petcare.enums.CareLogStatus;
 
@@ -14,6 +17,8 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "is_deleted = 'FALSE'")
+@SQLDelete(sql = "UPDATE care_log SET is_deleted = 'TRUE' WHERE care_log_id = ?")
 public class CareLog extends BaseTimeEntity {
 
     @Id
@@ -22,6 +27,9 @@ public class CareLog extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private CareLogStatus careLogStatus;
+
+    @Enumerated(EnumType.STRING)
+    private IsDeleted isDeleted;
 
     private LocalDate logDate;
 
@@ -44,6 +52,7 @@ public class CareLog extends BaseTimeEntity {
                 .petCare(petCare)
                 .careLogStatus(careLogStatus)
                 .logDate(LocalDate.now())
+                .isDeleted(IsDeleted.FALSE)
                 .build();
         member.getCareLogList().add(careLog);
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCare.java
@@ -1,10 +1,12 @@
 package org.retriever.server.dailypet.domain.petcare.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
+import org.retriever.server.dailypet.domain.model.IsDeleted;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
-import org.retriever.server.dailypet.domain.petcare.enums.PetCareStatus;
 import org.retriever.server.dailypet.domain.petcare.exception.CareCountExceededException;
 import org.retriever.server.dailypet.domain.petcare.exception.CareCountIsZeroException;
 
@@ -17,6 +19,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Where(clause = "is_deleted = 'FALSE'")
+@SQLDelete(sql = "UPDATE pet_care SET is_deleted = 'TRUE' WHERE pet_care_id = ?")
 public class PetCare extends BaseTimeEntity {
 
     @Id
@@ -30,13 +34,13 @@ public class PetCare extends BaseTimeEntity {
     private Boolean isPushAgree;
 
     @Enumerated(EnumType.STRING)
-    private PetCareStatus petCareStatus;
+    private IsDeleted isDeleted;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petId", nullable = false)
     private Pet pet;
 
-    @OneToMany(mappedBy = "petCare", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "petCare", cascade = CascadeType.ALL)
     @Builder.Default
     private List<PetCareAlarm> petCareAlarmList = new ArrayList<>();
 
@@ -49,7 +53,7 @@ public class PetCare extends BaseTimeEntity {
                 .careName(dto.getCareName())
                 .totalCountPerDay(dto.getTotalCountPerDay())
                 .isPushAgree(false)
-                .petCareStatus(PetCareStatus.ACTIVE)
+                .isDeleted(IsDeleted.FALSE)
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareAlarm.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareAlarm.java
@@ -1,8 +1,10 @@
 package org.retriever.server.dailypet.domain.petcare.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
-import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
+import org.retriever.server.dailypet.domain.model.IsDeleted;
 import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
 
 import javax.persistence.*;
@@ -12,6 +14,8 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Where(clause = "is_deleted = 'FALSE'")
+@SQLDelete(sql = "UPDATE pet_care_alarm SET is_deleted = 'TRUE' WHERE pet_care_alarm_id = ?")
 public class PetCareAlarm extends BaseTimeEntity {
 
     @Id
@@ -25,9 +29,13 @@ public class PetCareAlarm extends BaseTimeEntity {
     @JoinColumn(name = "petCareId", nullable = false)
     private PetCare petCare;
 
+    @Enumerated(EnumType.STRING)
+    private IsDeleted isDeleted;
+
     public static PetCareAlarm from(CustomDayOfWeek dayOfWeek) {
         return PetCareAlarm.builder()
                 .dayOfWeek(dayOfWeek)
+                .isDeleted(IsDeleted.FALSE)
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/enums/PetCareStatus.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/enums/PetCareStatus.java
@@ -1,6 +1,0 @@
-package org.retriever.server.dailypet.domain.petcare.enums;
-
-public enum PetCareStatus {
-    ACTIVE,
-    DELETED
-}

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
@@ -7,6 +7,7 @@ import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRol
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
@@ -75,6 +76,16 @@ public class FamilyFactory {
                 .invitationCode("1234567890")
                 .familyMemberList(new ArrayList<>())
                 .petList(new ArrayList<>(List.of(Pet.builder().petName(name1).build(), Pet.builder().petName(name2).build())))
+                .build();
+    }
+
+    public static Family createTestFamilyWithFamilyMember(FamilyMember familyMember) {
+        return Family.builder()
+                .familyName("testFamily")
+                .familyStatus(FamilyStatus.ACTIVE)
+                .invitationCode("1234567890")
+                .familyMemberList(List.of(familyMember))
+                .petList(new ArrayList<>())
                 .build();
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetCareFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetCareFactory.java
@@ -1,7 +1,10 @@
 package org.retriever.server.dailypet.domain.common.factory;
 
+import org.retriever.server.dailypet.domain.model.IsDeleted;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCareAlarm;
 import org.retriever.server.dailypet.domain.petcare.enums.CustomDayOfWeek;
 
 import java.util.List;
@@ -23,6 +26,16 @@ public class PetCareFactory {
                 .careName("testCare")
                 .totalCountPerDay(5)
                 .dayOfWeeks(List.of(CustomDayOfWeek.MON))
+                .build();
+    }
+
+    public static PetCare createTestPetCareWithPetAndAlarm(Pet pet, PetCareAlarm petCareAlarm) {
+        return PetCare.builder()
+                .careName("testCare")
+                .totalCountPerDay(5)
+                .isDeleted(IsDeleted.FALSE)
+                .pet(pet)
+                .petCareAlarmList(List.of(petCareAlarm))
                 .build();
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
@@ -1,5 +1,6 @@
 package org.retriever.server.dailypet.domain.common.factory;
 
+import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
@@ -64,6 +65,22 @@ public class PetFactory {
                 .petType(PetType.DOG)
                 .petKindName("리트리버")
                 .information("리트리버")
+                .build();
+    }
+
+    public static Pet createTestPetWithFamilyAndPetKind(Family family, PetKind petKind) {
+        return Pet.builder()
+                .petId(1L)
+                .petName("petTest")
+                .profileImageUrl("testUrl")
+                .birthDate(LocalDate.of(2022, 8, 13))
+                .weight(5.8)
+                .registerNumber("12345678")
+                .isNeutered(Boolean.TRUE)
+                .gender(Gender.MALE)
+                .petStatus(PetStatus.ACTIVE)
+                .family(family)
+                .petKind(petKind)
                 .build();
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
@@ -24,7 +24,7 @@ public class PetFactory {
                 .registerNumber("12345678")
                 .isNeutered(Boolean.TRUE)
                 .gender(Gender.MALE)
-                .status(PetStatus.ACTIVE)
+                .petStatus(PetStatus.ACTIVE)
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/family/entity/FamilyMemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/entity/FamilyMemberTest.java
@@ -1,14 +1,13 @@
 package org.retriever.server.dailypet.domain.family.entity;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.retriever.server.dailypet.domain.common.factory.FamilyFactory;
 import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
 import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.model.IsDeleted;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class FamilyMemberTest {
 
@@ -26,5 +25,6 @@ class FamilyMemberTest {
         // then
         assertThat(familyMember.getFamily()).isEqualTo(family);
         assertThat(familyMember.getMember()).isEqualTo(member);
+        assertThat(familyMember.getIsDeleted()).isEqualTo(IsDeleted.FALSE);
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
@@ -1,22 +1,23 @@
 package org.retriever.server.dailypet.domain.member.service;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.retriever.server.dailypet.domain.common.factory.FamilyFactory;
 import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.SignUpResponse;
 import org.retriever.server.dailypet.domain.member.dto.response.SnsLoginResponse;
 import org.retriever.server.dailypet.domain.member.entity.Member;
-import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberException;
 import org.retriever.server.dailypet.domain.member.exception.DuplicateMemberNicknameException;
 import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundException;
@@ -50,6 +51,8 @@ class MemberServiceTest {
     MemberQueryRepository memberQueryRepository;
     @Mock
     SecurityUtil securityUtil;
+    @Mock
+    FamilyRepository familyRepository;
 
     @InjectMocks
     MemberService memberService;
@@ -201,12 +204,44 @@ class MemberServiceTest {
 
         // given
         Member member = MemberFactory.createTestMember();
+        Family family = FamilyFactory.createTestFamily();
+        FamilyMember familyMember = FamilyMember.createFamilyMember(member, family);
+
         given(securityUtil.getMemberByUserDetails()).willReturn(member);
+        given(memberQueryRepository.findFamilyByMemberId(any())).willReturn(List.of(familyMember));
 
         // when
         memberService.deleteMember();
 
         // then
-        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.DELETED);
+        verify(memberRepository,times(1)).delete(any());
+        verify(familyRepository, times(1)).delete(any());
     }
+
+//    void init() {
+//        // given
+//        Member member = MemberFactory.createTestMember();
+//        Family family = FamilyFactory.createTestFamily();
+//        FamilyMember familyMember = FamilyMember.createFamilyMember(member, family);
+//        Pet pet = PetFactory.createTestPetWithFamilyAndPetKind(family, PetFactory.createTestPetKind());
+//        PetCareAlarm petCareAlarm = PetCareAlarm.from(CustomDayOfWeek.MON);
+//        PetCare petCare = PetCareFactory.createTestPetCareWithPetAndAlarm(pet, petCareAlarm);
+//        CareLog careLog = CareLog.of(member, pet, petCare, CareLogStatus.CHECK);
+//
+//        given(securityUtil.getMemberByUserDetails()).willReturn(member);
+//        given(memberQueryRepository.findFamilyByMemberId(any())).willReturn(List.of(familyMember));
+//
+//        // when
+//        memberService.deleteMember();
+//        // then
+//        assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.DELETED);
+//        assertThat(family.getFamilyStatus()).isEqualTo(FamilyStatus.DELETED);
+//        assertThat(familyMember.getIsDeleted()).isEqualTo(IsDeleted.TRUE);
+//        assertThat(pet.getPetStatus()).isEqualTo(PetStatus.DELETED);
+//        assertThat(petCare.getIsDeleted()).isEqualTo(IsDeleted.TRUE);
+//        assertThat(careLog.getIsDeleted()).isEqualTo(IsDeleted.TRUE);
+//        assertThat(petCareAlarm.getIsDeleted()).isEqualTo(IsDeleted.TRUE);
+//        verify(memberRepository, times(1)).delete(any());
+//        verify(familyRepository, times(1)).delete(any());
+//    }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/entity/PetTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/entity/PetTest.java
@@ -28,6 +28,6 @@ class PetTest {
         assertThat(pet.getProfileImageUrl()).isEqualTo(imageUrl);
         assertThat(pet.getWeight()).isEqualTo(request.getWeight());
         assertThat(pet.getIsNeutered()).isEqualTo(request.getIsNeutered());
-        assertThat(pet.getStatus()).isEqualTo(PetStatus.ACTIVE);
+        assertThat(pet.getPetStatus()).isEqualTo(PetStatus.ACTIVE);
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/petcare/entity/PetCareTest.java
@@ -3,8 +3,8 @@ package org.retriever.server.dailypet.domain.petcare.entity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.retriever.server.dailypet.domain.common.factory.PetCareFactory;
+import org.retriever.server.dailypet.domain.model.IsDeleted;
 import org.retriever.server.dailypet.domain.petcare.dto.request.CreatePetCareRequest;
-import org.retriever.server.dailypet.domain.petcare.enums.PetCareStatus;
 import org.retriever.server.dailypet.domain.petcare.exception.CareCountExceededException;
 import org.retriever.server.dailypet.domain.petcare.exception.CareCountIsZeroException;
 
@@ -27,7 +27,7 @@ class PetCareTest {
         assertThat(petCare.getCareName()).isEqualTo(petCareRequest.getCareName());
         assertThat(petCare.getTotalCountPerDay()).isEqualTo(petCareRequest.getTotalCountPerDay());
         assertThat(petCare.getIsPushAgree()).isEqualTo(Boolean.FALSE);
-        assertThat(petCare.getPetCareStatus()).isEqualTo(PetCareStatus.ACTIVE);
+        assertThat(petCare.getIsDeleted()).isEqualTo(IsDeleted.FALSE);
     }
 
     @Test


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/88
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 회원 탈퇴 시, 관련 그룹, 반려동물, 케어 항목 등 모두 삭제됨
- @ Where(clause = "is_deleted = 'FALSE'")
- @ SQLDelete(sql = "UPDATE 테이블명 SET is_deleted = 'TRUE' WHERE ID= ?") 사용
- CascadeType을 이용해서 삭제 전파
- Member -> FamilMember & CareLog
- Family -> Pet -> PetCare -> PetCareAlarm

## Test Checklist

- [ ] 

## To Client

- 그룹 리더일 경우, 삭제하는 경우 등에 대한 처리는 마이페이지 작업하면서 진행할 예정입니다.
- 우선 클라이언트 테스트를 위해서 회원 탈퇴 시 모두 삭제
