### PR TITLE
Fix: API Response 수정, GroupType 추가, 1인 가족 생성 API

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -66,6 +66,18 @@ public class FamilyController {
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "1인 가족 생성", description = "1인 가족을 생성하고 해당 멤버는 가족 리더가 된다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "1인 가족 생성"),
+            @ApiResponse(responseCode = "400", description = "가족 생성 오류"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @PostMapping("/family/alone")
+    public ResponseEntity<CreateFamilyResponse> createFamilyAlone() throws IOException {
+        return ResponseEntity.ok(familyService.createFamilyAlone());
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "가족 초대 코드 입력", description = "가족을 찾기 위해 초대 코드를 입력하고 가족 정보를 반환한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "가족 검색 성공"),

--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -47,9 +47,9 @@ public class FamilyController {
             @ApiResponse(responseCode = "409", description = "사용 중인 중복 가족 이름"),
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
-    @PostMapping("/validation/family-role-name")
-    public ResponseEntity<Void> validateFamilyRoleName(@RequestBody @Valid ValidateFamilyRoleNameRequest dto) {
-        familyService.validateFamilyRoleName(dto);
+    @PostMapping("/validation/families/{familyId}/family-role-name")
+    public ResponseEntity<Void> validateFamilyRoleName(@PathVariable Long familyId, @RequestBody @Valid ValidateFamilyRoleNameRequest dto) {
+        familyService.validateFamilyRoleName(familyId, dto);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/FamilyMemberInfo.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/FamilyMemberInfo.java
@@ -1,0 +1,26 @@
+package org.retriever.server.dailypet.domain.family.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FamilyMemberInfo {
+
+    private Long memberId;
+
+    private String familyRoleName;
+
+    private String profileImageUrl;
+
+    public FamilyMemberInfo(FamilyMember familyMember) {
+        this.memberId = familyMember.getMember().getId();
+        this.familyRoleName = familyMember.getMember().getFamilyRoleName();
+        this.profileImageUrl = familyMember.getMember().getProfileImageUrl();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/FindFamilyWithInvitationCodeResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/FindFamilyWithInvitationCodeResponse.java
@@ -2,6 +2,10 @@ package org.retriever.server.dailypet.domain.family.dto.response;
 
 import lombok.*;
 import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -15,11 +19,16 @@ public class FindFamilyWithInvitationCodeResponse {
 
     private int familyMemberCount;
 
-    public static FindFamilyWithInvitationCodeResponse from(Family family) {
+    private List<FamilyMemberInfo> familyMemberList;
+
+    public static FindFamilyWithInvitationCodeResponse of(Family family, List<FamilyMember> familyMembers) {
         return FindFamilyWithInvitationCodeResponse.builder()
                 .familyId(family.getFamilyId())
                 .familyName(family.getFamilyName())
-                .familyMemberCount(family.getFamilyMemberList().size())
+                .familyMemberCount(familyMembers.size())
+                .familyMemberList(familyMembers.stream()
+                        .map(FamilyMemberInfo::new)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/entity/Family.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.Where;
 import org.retriever.server.dailypet.domain.diary.entity.Diary;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
 import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
@@ -35,6 +36,9 @@ public class Family extends BaseTimeEntity {
     @Column(nullable = false, unique = true, length = 10)
     private String invitationCode;
 
+    @Enumerated(EnumType.STRING)
+    private GroupType groupType;
+
     @OneToMany(mappedBy = "family", cascade = CascadeType.PERSIST)
     @Builder.Default
     private List<FamilyMember> familyMemberList = new ArrayList<>();
@@ -53,6 +57,17 @@ public class Family extends BaseTimeEntity {
                 .familyStatus(FamilyStatus.ACTIVE)
                 .invitationCode(invitationCode)
                 .familyMemberList(new ArrayList<>())
+                .groupType(GroupType.FAMILY)
+                .build();
+    }
+
+    public static Family createFamilyAlone() {
+        return Family.builder()
+                .familyName(null)
+                .familyStatus(FamilyStatus.ACTIVE)
+                .invitationCode(null)
+                .familyMemberList(new ArrayList<>())
+                .groupType(GroupType.ALONE)
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/family/enums/GroupType.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/enums/GroupType.java
@@ -1,0 +1,5 @@
+package org.retriever.server.dailypet.domain.family.enums;
+
+public enum GroupType {
+    FAMILY, ALONE
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/repository/FamilyQueryRepository.java
@@ -1,0 +1,25 @@
+package org.retriever.server.dailypet.domain.family.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class FamilyQueryRepository {
+
+    private final EntityManager entityManager;
+
+    public List<FamilyMember> findMembersByFamilyId(Long familyId) {
+        return entityManager.createQuery(
+                        "select fm from FamilyMember fm" +
+                                " join fetch fm.member m" +
+                                " join fetch fm.family f " +
+                                " where f.familyId = :familyId", FamilyMember.class)
+                .setParameter("familyId", familyId)
+                .getResultList();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -56,9 +56,7 @@ public class FamilyService {
 
         // 멤버 조회 및 권한 지정
         Member member = securityUtil.getMemberByUserDetails();
-        member.setFamilyLeader();
-        member.changeFamilyRoleName(dto.getFamilyRoleName());
-        member.changeProgressStatusToGroup();
+        member.createGroup(dto.getFamilyRoleName());
 
         // 새로운 가족 그룹 생성 - 초대코드 생성
         String invitationCode = InvitationCodeUtil.createInvitationCode();
@@ -71,6 +69,22 @@ public class FamilyService {
 
         return CreateFamilyResponse.builder()
                 .familyId(newFamily.getFamilyId())
+                .build();
+    }
+    // TODO : 가족 그룹 생성 중복 로직 디자인패턴 적용해보기
+    @Transactional
+    public CreateFamilyResponse createFamilyAlone() {
+        Member member = securityUtil.getMemberByUserDetails();
+        member.createGroup(null);
+
+        Family familyAlone = Family.createFamilyAlone();
+        FamilyMember familyMember = FamilyMember.createFamilyMember(member, familyAlone);
+
+        familyAlone.insertNewMember(familyMember);
+        familyRepository.save(familyAlone);
+
+        return CreateFamilyResponse.builder()
+                .familyId(familyAlone.getFamilyId())
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -38,13 +38,15 @@ public class FamilyService {
         }
     }
 
-    // TODO : 쿼리 직접 만들어서 한 번에 해당 가족에 속한 member 참조하기 (현재는 familyMember.getMember()로 가져옴)
-    public void validateFamilyRoleName(ValidateFamilyRoleNameRequest dto) {
-        Member member = securityUtil.getMemberByUserDetails();
-        List<FamilyMember> familyMemberList = member.getFamilyMemberList();
+    public void validateFamilyRoleName(Long familyId, ValidateFamilyRoleNameRequest dto) {
+        List<FamilyMember> familyMemberList = familyQueryRepository.findMembersByFamilyId(familyId);
 
         if (familyMemberList.stream()
-                .anyMatch(x -> x.getMember().getFamilyRoleName().equals(dto.getFamilyRoleName()))) {
+                .anyMatch(x -> x.getMember()
+                        .getFamilyRoleName()
+                        .equals(dto.getFamilyRoleName())
+                )
+        ) {
             throw new DuplicateFamilyRoleNameException();
         }
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -12,6 +12,7 @@ import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyRoleNameException;
 import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyQueryRepository;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.global.utils.invitationcode.InvitationCodeUtil;
@@ -28,6 +29,7 @@ import java.util.List;
 public class FamilyService {
 
     private final FamilyRepository familyRepository;
+    private final FamilyQueryRepository familyQueryRepository;
     private final SecurityUtil securityUtil;
 
     public void validateFamilyName(ValidateFamilyNameRequest dto) {
@@ -72,8 +74,9 @@ public class FamilyService {
 
     public FindFamilyWithInvitationCodeResponse findFamilyWithInvitationCode(String code) {
         Family family = familyRepository.findByInvitationCode(code).orElseThrow(FamilyNotFoundException::new);
+        List<FamilyMember> familyMembers = familyQueryRepository.findMembersByFamilyId(family.getFamilyId());
 
-        return FindFamilyWithInvitationCodeResponse.from(family);
+        return FindFamilyWithInvitationCodeResponse.of(family, familyMembers);
     }
 
     @Transactional

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/SnsLoginResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/response/SnsLoginResponse.java
@@ -1,10 +1,15 @@
 package org.retriever.server.dailypet.domain.member.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.pet.dto.response.PetInfoResponse;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -12,22 +17,37 @@ import java.util.List;
 @Getter
 public class SnsLoginResponse {
 
-    @Schema(description = "유저 프로필 이름")
     private String nickName;
 
-    @Schema(description = "유저 SNS email")
     private String email;
 
-    @Schema(description = "jwt Token")
     private String jwtToken;
 
-    @Schema(description = "familyId")
     private Long familyId;
 
     private String familyName;
 
     private String invitationCode;
 
-    @Schema(description = "petId List")
-    private List<Long> petIdList = new ArrayList<>();
+    private GroupType groupType;
+
+    private String profileImageUrl;
+
+    private List<PetInfoResponse> petList = new ArrayList<>();
+
+    public static SnsLoginResponse of(Member member, Family family, String token, List<Pet> petList) {
+        return SnsLoginResponse.builder()
+                .nickName(member.getNickName())
+                .email(member.getEmail())
+                .jwtToken(token)
+                .familyId(family.getFamilyId())
+                .familyName(family.getFamilyName())
+                .invitationCode(family.getInvitationCode())
+                .groupType(family.getGroupType())
+                .profileImageUrl(member.getProfileImageUrl())
+                .petList(petList.stream()
+                        .map(PetInfoResponse::new)
+                        .collect(Collectors.toList()))
+                .build();
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -117,6 +117,12 @@ public class Member extends BaseTimeEntity {
                 .build();
     }
 
+    public void createGroup(String familyRoleName) {
+        setFamilyLeader();
+        changeFamilyRoleName(familyRoleName);
+        changeProgressStatusToGroup();
+    }
+
     public void setFamilyLeader() {
         this.roleType = RoleType.FAMILY_LEADER;
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/PetInfoResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/PetInfoResponse.java
@@ -13,7 +13,7 @@ public class PetInfoResponse {
 
     private String petName;
 
-    PetInfoResponse(Pet pet) {
+    public PetInfoResponse(Pet pet) {
         this.petId = pet.getPetId();
         this.petName = pet.getPetName();
     }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/RegisterPetResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/RegisterPetResponse.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.pet.dto.response;
 
 import lombok.*;
 import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 
 import java.util.List;
@@ -17,17 +18,23 @@ public class RegisterPetResponse {
 
     private String familyName;
 
-    private String familyRoleName;
-
-    private List<PetInfoResponse> petList;
+    private String nickName;
 
     private String invitationCode;
+
+    private GroupType groupType;
+
+    private String profileImageUrl;
+
+    private List<PetInfoResponse> petList;
 
     public static RegisterPetResponse of(Member member, Family family) {
         return RegisterPetResponse.builder()
                 .familyId(family.getFamilyId())
                 .familyName(family.getFamilyName())
-                .familyRoleName(member.getFamilyRoleName())
+                .nickName(member.getNickName())
+                .groupType(family.getGroupType())
+                .profileImageUrl(member.getProfileImageUrl())
                 .petList(family.getPetList().stream()
                         .map(PetInfoResponse::new)
                         .collect(Collectors.toList()))

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
@@ -9,6 +9,7 @@ import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithIn
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
+import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
 import java.util.ArrayList;
@@ -87,5 +88,11 @@ public class FamilyFactory {
                 .familyMemberList(List.of(familyMember))
                 .petList(new ArrayList<>())
                 .build();
+    }
+
+    public static List<FamilyMember> createTestFamilyMember(Member member, Family family) {
+        return List.of(
+                FamilyMember.createFamilyMember(member, family)
+        );
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
@@ -9,6 +9,7 @@ import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithIn
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 
@@ -27,6 +28,7 @@ public class FamilyFactory {
                 .invitationCode("1234567890")
                 .familyMemberList(new ArrayList<>())
                 .petList(new ArrayList<>())
+                .groupType(GroupType.FAMILY)
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
@@ -95,4 +95,11 @@ public class FamilyFactory {
                 FamilyMember.createFamilyMember(member, family)
         );
     }
+
+    public static List<FamilyMember> createTestDuplicateFamilyMember(String name1, String name2) {
+        return List.of(
+                FamilyMember.builder().member((MemberFactory.createTestFamilyRoleNameMember(name1))).build(),
+                FamilyMember.builder().member((MemberFactory.createTestFamilyRoleNameMember(name2))).build());
+    }
 }
+

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -27,6 +27,7 @@ public class MemberFactory {
 
     public static Member createTestMember() {
         return Member.builder()
+                .id(1L)
                 .email("test@naver.com")
                 .nickName("test")
                 .profileImageUrl("abcdefghijk")

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -179,4 +179,11 @@ public class MemberFactory {
                 .petIdList(List.of(1L, 2L, 3L))
                 .build();
     }
+
+    public static Member createTestFamilyRoleNameMember(String name) {
+        return Member
+                .builder()
+                .familyRoleName(name)
+                .build();
+    }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.common.factory;
 
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
 import org.retriever.server.dailypet.domain.member.dto.request.SignUpRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
@@ -11,6 +12,7 @@ import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.enums.AccountStatus;
 import org.retriever.server.dailypet.domain.member.enums.ProviderType;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
+import org.retriever.server.dailypet.domain.pet.dto.response.PetInfoResponse;
 import org.retriever.server.dailypet.global.config.security.CustomUserDetails;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -19,6 +21,7 @@ import org.springframework.security.core.Authentication;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MemberFactory {
 
@@ -90,10 +93,10 @@ public class MemberFactory {
                 .build();
     }
 
-    public static List<FamilyMember> createTestFamilyMember(Long familyId) {
+    public static List<FamilyMember> createTestFamilyMember(Long familyId, String familyName) {
         return List.of(FamilyMember.builder()
                 .member(Member.builder().build())
-                .family(Family.builder().familyId(familyId).build())
+                .family(Family.builder().familyId(familyId).familyName(familyName).build())
                 .build());
     }
 
@@ -110,10 +113,12 @@ public class MemberFactory {
                 .nickName("test")
                 .email("test@naver.com")
                 .jwtToken("testToken")
-                .familyId(-1L)
+                .familyId(null)
                 .familyName("testFamily")
                 .invitationCode("testCode")
-                .petIdList(List.of(-1L))
+                .groupType(GroupType.FAMILY)
+                .profileImageUrl("testImageUrl")
+                .petList(new ArrayList<>())
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/family/entity/FamilyTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/entity/FamilyTest.java
@@ -6,7 +6,11 @@ import org.retriever.server.dailypet.domain.common.factory.FamilyFactory;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
 import org.retriever.server.dailypet.domain.family.enums.GroupType;
+import org.retriever.server.dailypet.domain.pet.dto.response.PetInfoResponse;
 import org.retriever.server.dailypet.global.utils.invitationcode.InvitationCodeUtil;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,5 +32,17 @@ class FamilyTest {
         assertThat(family.getFamilyStatus()).isEqualTo(FamilyStatus.ACTIVE);
         assertThat(family.getInvitationCode()).isEqualTo(invitationCode);
         assertThat(family.getGroupType()).isEqualTo(GroupType.FAMILY);
+    }
+
+    @Test
+    void null_test() {
+        Family family = Family.builder().build();
+        System.out.println("family.getFamilyName() = " + family.getFamilyName());
+        System.out.println("family.getFamilyId() = " + family.getFamilyId());
+        List<PetInfoResponse> list = family.getPetList().stream().map(PetInfoResponse::new).collect(Collectors.toList());
+        System.out.println("list.size() = " + list.size());
+
+        family = FamilyFactory.createTestFamily();
+        System.out.println("family.getFamilyName() = " + family.getFamilyName());
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/family/entity/FamilyTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/entity/FamilyTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.retriever.server.dailypet.domain.common.factory.FamilyFactory;
 import org.retriever.server.dailypet.domain.family.dto.request.CreateFamilyRequest;
 import org.retriever.server.dailypet.domain.family.enums.FamilyStatus;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
 import org.retriever.server.dailypet.global.utils.invitationcode.InvitationCodeUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,5 +27,6 @@ class FamilyTest {
         assertThat(family.getFamilyName()).isEqualTo(familyRequest.getFamilyName());
         assertThat(family.getFamilyStatus()).isEqualTo(FamilyStatus.ACTIVE);
         assertThat(family.getInvitationCode()).isEqualTo(invitationCode);
+        assertThat(family.getGroupType()).isEqualTo(GroupType.FAMILY);
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
@@ -113,12 +113,13 @@ class FamilyServiceTest {
         // given
         String name1 = "엄마";
         String name2 = "아빠";
-        Member member = MemberFactory.createTestMemberWithFamilyMemberList(name1, name2);
+        List<FamilyMember> familyMemberList = FamilyFactory.createTestDuplicateFamilyMember(name1, name2);
+
         ValidateFamilyRoleNameRequest request = FamilyFactory.createValidateFamilyRoleNameRequest(name1);
-        when(securityUtil.getMemberByUserDetails()).thenReturn(member);
+        when(familyQueryRepository.findMembersByFamilyId(any())).thenReturn(familyMemberList);
 
         // when, then
-        assertThrows(DuplicateFamilyRoleNameException.class, () -> familyService.validateFamilyRoleName(request));
+        assertThrows(DuplicateFamilyRoleNameException.class, () -> familyService.validateFamilyRoleName(any(), request));
     }
 
     @DisplayName("가족 생성 - 가족 정상 생성")

--- a/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
@@ -13,19 +13,22 @@ import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyReques
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
+import org.retriever.server.dailypet.domain.family.dto.response.FamilyMemberInfo;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyNameException;
 import org.retriever.server.dailypet.domain.family.exception.DuplicateFamilyRoleNameException;
 import org.retriever.server.dailypet.domain.family.exception.FamilyNotFoundException;
+import org.retriever.server.dailypet.domain.family.repository.FamilyQueryRepository;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
 import org.retriever.server.dailypet.domain.member.enums.RoleType;
-import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +44,7 @@ class FamilyServiceTest {
     FamilyRepository familyRepository;
 
     @Mock
-    MemberRepository memberRepository;
+    FamilyQueryRepository familyQueryRepository;
 
     @Mock
     SecurityUtil securityUtil;
@@ -68,17 +71,24 @@ class FamilyServiceTest {
     void find_family_with_invitation_code_success() {
 
         // given
+        Member member = MemberFactory.createTestMember();
         Family family = FamilyFactory.createTestFamily();
+        List<FamilyMember> testFamilyMemberList = FamilyFactory.createTestFamilyMember(member, family);
         String invitationCode = "1234567890";
         when(familyRepository.findByInvitationCode(any())).thenReturn(Optional.of(family));
+        when(familyQueryRepository.findMembersByFamilyId(any())).thenReturn(testFamilyMemberList);
 
         // when
         FindFamilyWithInvitationCodeResponse response = familyService.findFamilyWithInvitationCode(invitationCode);
+        FamilyMemberInfo familyMemberInfo = response.getFamilyMemberList().get(0);
 
         // then
         assertThat(response.getFamilyId()).isEqualTo(family.getFamilyId());
         assertThat(response.getFamilyName()).isEqualTo(family.getFamilyName());
-        assertThat(response.getFamilyMemberCount()).isEqualTo(family.getFamilyMemberList().size());
+        assertThat(response.getFamilyMemberCount()).isEqualTo(testFamilyMemberList.size());
+        assertThat(familyMemberInfo.getMemberId()).isEqualTo(member.getId());
+        assertThat(familyMemberInfo.getFamilyRoleName()).isEqualTo(member.getFamilyRoleName());
+        assertThat(familyMemberInfo.getProfileImageUrl()).isEqualTo(member.getProfileImageUrl());
     }
 
     @DisplayName("가족 조회 - 초대 코드와 일치하는 가족이 없을 경우 FamilyNotFoundException 발생")

--- a/src/test/java/org/retriever/server/dailypet/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/controller/MemberControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.retriever.server.dailypet.domain.common.ControllerTest;
 import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
 import org.retriever.server.dailypet.domain.member.dto.request.SnsLoginRequest;
 import org.retriever.server.dailypet.domain.member.dto.request.ValidateMemberNicknameRequest;
 import org.retriever.server.dailypet.domain.member.dto.response.CalculateDayResponse;
@@ -26,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser
 class MemberControllerTest extends ControllerTest {
 
-    @DisplayName("로그인 시도 시 회원 확인 후 정상 로그인, familyId, petId는 모두 -1L")
+    @DisplayName("로그인 시도 시 회원 확인 후 정상 로그인, familyId, petId는 모두 Null")
     @Test
     void checkMemberAndLogin() throws Exception {
 
@@ -51,10 +52,12 @@ class MemberControllerTest extends ControllerTest {
                 .andExpect(jsonPath("email").value(snsLoginRequest.getEmail()))
                 .andExpect(jsonPath("nickName").value(snsLoginRequest.getSnsNickName()))
                 .andExpect(jsonPath("jwtToken").value(snsLoginResponse.getJwtToken()))
-                .andExpect(jsonPath("familyId").value(-1L))
+                .andExpect(jsonPath("familyId").value(isNull()))
                 .andExpect(jsonPath("familyName").value("testFamily"))
                 .andExpect(jsonPath("invitationCode").value("testCode"))
-                .andExpect(jsonPath("petIdList[0]").value(-1L))
+                .andExpect(jsonPath("groupType").value(GroupType.FAMILY))
+                .andExpect(jsonPath("profileImageUrl").value("testImageUrl"))
+                .andExpect(jsonPath("petList[0]").value(isNull()))
                 .andDo(print())
                 .andReturn()
                 .getResponse()

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
@@ -57,7 +57,7 @@ class MemberServiceTest {
     @InjectMocks
     MemberService memberService;
 
-    @DisplayName("로그인 - 가입된 회원인 경우 JWT 토큰과 가족과 펫이 등록되어 있지 않으면 각각 -1이 리턴된다.")
+    @DisplayName("로그인 - 가입된 회원인 경우 JWT 토큰과 가족과 펫이 등록되어 있지 않으면 각각 0L과 빈 리스트가 리턴된다.")
     @Test
     void check_member_success_and_login_and_not_register_group_pet() {
 
@@ -76,20 +76,23 @@ class MemberServiceTest {
                 () -> assertEquals(snsLoginResponse.getEmail(), member.getEmail()),
                 () -> assertEquals(snsLoginResponse.getNickName(), member.getNickName()),
                 () -> assertEquals(snsLoginResponse.getJwtToken(), testToken),
-                () -> assertEquals(snsLoginResponse.getFamilyId(), -1L),
-                () -> assertEquals(snsLoginResponse.getPetIdList(), List.of(-1L))
+                () -> assertEquals(snsLoginResponse.getFamilyId(), 0L),
+                () -> assertNull(snsLoginResponse.getFamilyName()),
+                () -> assertEquals(snsLoginResponse.getProfileImageUrl(), member.getProfileImageUrl()),
+                () -> assertEquals(snsLoginResponse.getPetList().isEmpty(), Boolean.TRUE)
         );
     }
 
-    @DisplayName("로그인 - 가입된 회원인 경우 JWT 토큰과 가족이 등록되어 있는 경우 해당 familyId와 펫이 등록되어 있지 않으면 -1이 리턴된다.")
+    @DisplayName("로그인 - 가입된 회원인 경우 JWT 토큰과 가족이 등록되어 있는 경우 해당 familyId와 펫이 등록되어 있지 않으면 빈 리스트가 리턴된다.")
     @Test
     void check_member_success_and_login_and_register_family() {
 
         // given
         SnsLoginRequest snsLoginRequest = MemberFactory.createSnsLoginRequest();
         Long testFamilyId = 3L;
+        String testFamilyName = "testFamily";
         Member member = MemberFactory.createTestMember();
-        List<FamilyMember> testFamilyMember = MemberFactory.createTestFamilyMember(testFamilyId);
+        List<FamilyMember> testFamilyMember = MemberFactory.createTestFamilyMember(testFamilyId, testFamilyName);
         String testToken = "jwtToken";
         when(memberRepository.findByEmail(any())).thenReturn(Optional.of(member));
         when(memberQueryRepository.findFamilyByMemberId(member.getId())).thenReturn(testFamilyMember);
@@ -104,7 +107,9 @@ class MemberServiceTest {
                 () -> assertEquals(snsLoginResponse.getNickName(), member.getNickName()),
                 () -> assertEquals(snsLoginResponse.getJwtToken(), testToken),
                 () -> assertEquals(snsLoginResponse.getFamilyId(), testFamilyId),
-                () -> assertEquals(snsLoginResponse.getPetIdList(), List.of(-1L))
+                () -> assertNotNull(snsLoginResponse.getFamilyName()),
+                () -> assertEquals(snsLoginResponse.getProfileImageUrl(), member.getProfileImageUrl()),
+                () -> assertEquals(snsLoginResponse.getPetList().isEmpty(), Boolean.TRUE)
         );
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
@@ -132,7 +132,9 @@ class PetServiceTest {
         verify(petRepository, times(1)).save(any());
         assertThat(response.getFamilyId()).isEqualTo(family.getFamilyId());
         assertThat(response.getFamilyName()).isEqualTo(family.getFamilyName());
-        assertThat(response.getFamilyRoleName()).isEqualTo(member.getFamilyRoleName());
+        assertThat(response.getNickName()).isEqualTo(member.getNickName());
+        assertThat(response.getGroupType()).isEqualTo(family.getGroupType());
+        assertThat(response.getProfileImageUrl()).isEqualTo(member.getProfileImageUrl());
         assertThat(response.getInvitationCode()).isEqualTo(family.getInvitationCode());
         assertThat(response.getPetList()).isNotNull();
         assertThat(response.getPetList().get(0).getPetName()).isEqualTo(request.getPetName());


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 초대 코드 그룹 조회 response에 familyNameInfo (memberId, 가족 내 닉네임, 프로필 사진) 추가
- 가족 내 닉네임 검증 URL에 familyId 추가
- 1인 가족 생성 API 추가 및 GroupType 추가
- 로그인 response에 groupType, profileImage, PetList 추가 (그룹, 펫 없으면 null 반환)
- 반려동물 등록 response에 groupType, profileImageUrl 추가, nickName으로 변경

## Test Checklist

- [ ] 

## To Client

- 요구사항 반영 완료입니다.
