### PR TITLE
Feat: AWS PresignedURL 적용

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/controller/MemberController.java
@@ -59,9 +59,8 @@ public class MemberController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/auth/sign-up")
-    public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestPart @Valid SignUpRequest dto,
-                                                                   @RequestPart MultipartFile image) throws IOException {
-        return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto, image));
+    public ResponseEntity<SignUpResponse> signUpAndRegisterProfile(@RequestBody @Valid SignUpRequest dto) throws IOException {
+        return ResponseEntity.ok(memberService.signUpAndRegisterProfile(dto));
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
@@ -73,8 +72,8 @@ public class MemberController {
     })
     @PatchMapping("/member/mypage/profile-image")
     public ResponseEntity<EditProfileImageResponse> editProfileImage(
-            @RequestPart MultipartFile image) throws IOException {
-        return ResponseEntity.ok(memberService.editProfileImage(image));
+            @RequestBody String profileImageUrl) throws IOException {
+        return ResponseEntity.ok(memberService.editProfileImage(profileImageUrl));
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)

--- a/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/dto/request/SignUpRequest.java
@@ -27,4 +27,6 @@ public class SignUpRequest {
     private Boolean isPushAgree;
 
     private Boolean isProfileInformationAgree;
+
+    private String profileImageUrl;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -99,11 +99,11 @@ public class Member extends BaseTimeEntity {
         this.accountProgressStatus = AccountProgressStatus.PROFILE;
     }
 
-    public static Member createNewMember(SignUpRequest signUpRequest, String url) {
+    public static Member createNewMember(SignUpRequest signUpRequest) {
         return Member.builder()
                 .email(signUpRequest.getEmail())
                 .nickName(signUpRequest.getNickName())
-                .profileImageUrl(url)
+                .profileImageUrl(signUpRequest.getProfileImageUrl())
                 .providerType(signUpRequest.getProviderType())
                 .deviceToken(signUpRequest.getDeviceToken())
                 .isPushAgree((signUpRequest.getIsPushAgree()))

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -25,7 +25,6 @@ import org.retriever.server.dailypet.global.utils.s3.S3FileUploader;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
@@ -70,12 +69,11 @@ public class MemberService {
     }
 
     @Transactional
-    public SignUpResponse signUpAndRegisterProfile(SignUpRequest dto, MultipartFile image) throws IOException {
+    public SignUpResponse signUpAndRegisterProfile(SignUpRequest dto) throws IOException {
         if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
             throw new DuplicateMemberException();
         }
-        String profileImageUrl = s3FileUploader.upload(image, "test");
-        Member signUpMember = Member.createNewMember(dto, profileImageUrl);
+        Member signUpMember = Member.createNewMember(dto);
 
         memberRepository.save(signUpMember);
 
@@ -87,10 +85,8 @@ public class MemberService {
     }
 
     @Transactional
-    public EditProfileImageResponse editProfileImage(MultipartFile image) throws IOException {
+    public EditProfileImageResponse editProfileImage(String profileImageUrl) throws IOException {
         Member member = securityUtil.getMemberByUserDetails();
-        String profileImageUrl = s3FileUploader.upload(image, "test");
-
         member.editProfileImageUrl(profileImageUrl);
 
         return EditProfileImageResponse.from(profileImageUrl);

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -15,7 +15,6 @@ import org.retriever.server.dailypet.domain.pet.enums.PetType;
 import org.retriever.server.dailypet.domain.pet.service.PetService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
@@ -64,10 +63,8 @@ public class PetController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/families/{familyId}/pet")
-    public ResponseEntity<RegisterPetResponse> registerPet(@RequestPart @Valid RegisterPetRequest dto,
-                                                           @RequestPart MultipartFile image,
-                                                           @PathVariable Long familyId) throws IOException {
-        return ResponseEntity.ok(petService.registerPet(dto, familyId, image));
+    public ResponseEntity<RegisterPetResponse> registerPet(@RequestBody @Valid RegisterPetRequest dto, @PathVariable Long familyId) throws IOException {
+        return ResponseEntity.ok(petService.registerPet(dto, familyId));
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/RegisterPetRequest.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/request/RegisterPetRequest.java
@@ -27,4 +27,6 @@ public class RegisterPetRequest {
     private Boolean isNeutered;
 
     private String registerNumber;
+
+    private String profileImageUrl;
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -66,10 +66,10 @@ public class Pet extends BaseTimeEntity {
     @Builder.Default
     private List<CareLog> careLogList = new ArrayList<>();
 
-    public static Pet createPet(RegisterPetRequest dto, String profileImageUrl) {
+    public static Pet createPet(RegisterPetRequest dto) {
         return Pet.builder()
                 .petName(dto.getPetName())
-                .profileImageUrl(profileImageUrl)
+                .profileImageUrl(dto.getProfileImageUrl())
                 .birthDate(dto.getBirthDate())
                 .weight(dto.getWeight())
                 .registerNumber(dto.getRegisterNumber())

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
@@ -23,7 +23,6 @@ import org.retriever.server.dailypet.global.utils.s3.S3FileUploader;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,15 +62,14 @@ public class PetService {
     }
 
     @Transactional
-    public RegisterPetResponse registerPet(RegisterPetRequest dto, Long familyId, MultipartFile image) throws IOException {
+    public RegisterPetResponse registerPet(RegisterPetRequest dto, Long familyId) throws IOException {
 
         Member member = securityUtil.getMemberByUserDetails();
         member.changeProgressStatusToPet();
         Family family = familyRepository.findById(familyId).orElseThrow(FamilyNotFoundException::new);
         PetKind petKind = petKindRepository.findByPetKindId(dto.getPetKindId()).orElseThrow(PetTypeNotFoundException::new);
-        String profileImageUrl = s3FileUploader.upload(image, "test");
 
-        Pet newPet = Pet.createPet(dto, profileImageUrl);
+        Pet newPet = Pet.createPet(dto);
 
         newPet.setPetKind(petKind);
         newPet.setFamily(family);

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/MemberFactory.java
@@ -140,6 +140,7 @@ public class MemberFactory {
                 .providerType(ProviderType.KAKAO)
                 .isPushAgree(Boolean.TRUE)
                 .isProfileInformationAgree(Boolean.TRUE)
+                .profileImageUrl("testProfileImage")
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
@@ -39,6 +39,7 @@ public class PetFactory {
                 .petType(PetType.DOG)
                 .weight(5.8)
                 .petKindId(1L)
+                .profileImageUrl("testProfile")
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/controller/MemberControllerTest.java
@@ -1,7 +1,9 @@
 package org.retriever.server.dailypet.domain.member.controller;
 
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.matchers.Null;
 import org.retriever.server.dailypet.domain.common.ControllerTest;
 import org.retriever.server.dailypet.domain.common.factory.MemberFactory;
 import org.retriever.server.dailypet.domain.family.enums.GroupType;
@@ -52,12 +54,12 @@ class MemberControllerTest extends ControllerTest {
                 .andExpect(jsonPath("email").value(snsLoginRequest.getEmail()))
                 .andExpect(jsonPath("nickName").value(snsLoginRequest.getSnsNickName()))
                 .andExpect(jsonPath("jwtToken").value(snsLoginResponse.getJwtToken()))
-                .andExpect(jsonPath("familyId").value(isNull()))
+                .andExpect(jsonPath("familyId").value(IsNull.nullValue()))
                 .andExpect(jsonPath("familyName").value("testFamily"))
                 .andExpect(jsonPath("invitationCode").value("testCode"))
-                .andExpect(jsonPath("groupType").value(GroupType.FAMILY))
+                .andExpect(jsonPath("groupType").value(GroupType.FAMILY.toString()))
                 .andExpect(jsonPath("profileImageUrl").value("testImageUrl"))
-                .andExpect(jsonPath("petList[0]").value(isNull()))
+                .andExpect(jsonPath("petList").isEmpty())
                 .andDo(print())
                 .andReturn()
                 .getResponse()

--- a/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/entity/MemberTest.java
@@ -20,14 +20,13 @@ class MemberTest {
         SignUpRequest signUpRequest = MemberFactory.createSignUpRequest();
 
         // when
-        String imageUrl = "test";
-        Member newMember = Member.createNewMember(signUpRequest, imageUrl);
+        Member newMember = Member.createNewMember(signUpRequest);
 
         // then
         assertThat(newMember.getId()).isNull();
         assertThat(newMember.getNickName()).isEqualTo(signUpRequest.getNickName());
         assertThat(newMember.getEmail()).isEqualTo(signUpRequest.getEmail());
-        assertThat(newMember.getProfileImageUrl()).isEqualTo(imageUrl);
+        assertThat(newMember.getProfileImageUrl()).isEqualTo(signUpRequest.getProfileImageUrl());
         assertThat(newMember.getProviderType()).isEqualTo(signUpRequest.getProviderType());
         assertThat(newMember.getDeviceToken()).isEqualTo(signUpRequest.getDeviceToken());
 

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
@@ -46,8 +46,6 @@ class MemberServiceTest {
     @Mock
     JwtTokenProvider jwtTokenProvider;
     @Mock
-    S3FileUploader s3FileUploader;
-    @Mock
     MemberQueryRepository memberQueryRepository;
     @Mock
     SecurityUtil securityUtil;
@@ -148,15 +146,12 @@ class MemberServiceTest {
         Member member = MemberFactory.createTestMember();
         SignUpRequest signUpRequest = MemberFactory.createSignUpRequest();
         String testToken = "jwtToken";
-        String imageURL = "testImageUrl";
-        MultipartFile image = MemberFactory.createMultipartFile();
         when(memberRepository.findByEmail(signUpRequest.getEmail())).thenReturn(Optional.empty());
         when(memberRepository.save(any())).thenReturn(member);
         when(jwtTokenProvider.createToken(any())).thenReturn(testToken);
-        when(s3FileUploader.upload(any(), any())).thenReturn(imageURL);
 
         // when
-        SignUpResponse signUpResponse = memberService.signUpAndRegisterProfile(signUpRequest, image);
+        SignUpResponse signUpResponse = memberService.signUpAndRegisterProfile(signUpRequest);
 
         // then
         assertAll(
@@ -173,11 +168,10 @@ class MemberServiceTest {
         // given
         Member member = MemberFactory.createTestMember();
         SignUpRequest signUpRequest = MemberFactory.createSignUpRequest();
-        MultipartFile image = MemberFactory.createMultipartFile();
         when(memberRepository.findByEmail(signUpRequest.getEmail())).thenReturn(Optional.of(member));
 
         // when, then
-        assertThrows(DuplicateMemberException.class, () -> memberService.signUpAndRegisterProfile(signUpRequest, image));
+        assertThrows(DuplicateMemberException.class, () -> memberService.signUpAndRegisterProfile(signUpRequest));
     }
 
     @DisplayName("회원 가입 - 회원 가입 도중 프로필 등록만 이탈한 회원일 경우 그룹이 존재하지 않고 FamilyNotFoundException 예외 발생")

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/entity/PetTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/entity/PetTest.java
@@ -18,14 +18,14 @@ class PetTest {
         RegisterPetRequest request = PetFactory.createRegisterPetRequest();
         String imageUrl = "testUrl";
         // when
-        Pet pet = Pet.createPet(request, imageUrl);
+        Pet pet = Pet.createPet(request);
 
         // then
         assertThat(pet.getPetName()).isEqualTo(request.getPetName());
         assertThat(pet.getBirthDate()).isEqualTo(request.getBirthDate());
         assertThat(pet.getGender()).isEqualTo(request.getGender());
         assertThat(pet.getRegisterNumber()).isEqualTo(request.getRegisterNumber());
-        assertThat(pet.getProfileImageUrl()).isEqualTo(imageUrl);
+        assertThat(pet.getProfileImageUrl()).isEqualTo(request.getProfileImageUrl());
         assertThat(pet.getWeight()).isEqualTo(request.getWeight());
         assertThat(pet.getIsNeutered()).isEqualTo(request.getIsNeutered());
         assertThat(pet.getPetStatus()).isEqualTo(PetStatus.ACTIVE);

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/service/PetServiceTest.java
@@ -13,7 +13,6 @@ import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.member.enums.AccountProgressStatus;
-import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
 import org.retriever.server.dailypet.domain.pet.dto.response.GetPetKindListResponse;
@@ -24,9 +23,7 @@ import org.retriever.server.dailypet.domain.pet.exception.DuplicatePetNameInFami
 import org.retriever.server.dailypet.domain.pet.exception.PetTypeNotFoundException;
 import org.retriever.server.dailypet.domain.pet.repository.PetKindRepository;
 import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
-import org.retriever.server.dailypet.global.utils.s3.S3FileUploader;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
-import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
 import java.util.List;
@@ -50,12 +47,6 @@ class PetServiceTest {
 
     @Mock
     PetKindRepository petKindRepository;
-
-    @Mock
-    MemberRepository memberRepository;
-
-    @Mock
-    S3FileUploader s3FileUploader;
 
     @Mock
     SecurityUtil securityUtil;
@@ -114,19 +105,16 @@ class PetServiceTest {
 
         // given
         Member member = MemberFactory.createTestMember();
-        MockMultipartFile file = MemberFactory.createMultipartFile();
         Family family = FamilyFactory.createTestFamily();
         PetKind petKind = PetFactory.createTestPetKind();
         RegisterPetRequest request = PetFactory.createRegisterPetRequest();
-        String imageUrl = "testUrl";
 
         given(familyRepository.findById(any())).willReturn(Optional.of(family));
-        given(s3FileUploader.upload(any(), any())).willReturn(imageUrl);
         given(petKindRepository.findByPetKindId(any())).willReturn(Optional.of(petKind));
         given(securityUtil.getMemberByUserDetails()).willReturn(member);
 
         // when
-        RegisterPetResponse response = petService.registerPet(request, family.getFamilyId(), file);
+        RegisterPetResponse response = petService.registerPet(request, family.getFamilyId());
 
         // then
         verify(petRepository, times(1)).save(any());


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/84
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- presignedURL 적용
- MultipartFile -> profileImageUrl로 변경된 부분
- 회원 프로필 등록
- 회원 프로필 이미지 수정
- 반려동물 등록

## Test Checklist

- [ ] 

## To Client

- 회원 프로필 등록
- 회원 프로필 이미지 수정
- 반려동물 등록 의 API에서 RequestPart와 MultipartFile이 삭제되었고 request에 profileImageUrl이 추가되었습니다.

이제 사진이 포함된 요청들 모두 Body에 담아서 보내면 됩니다.

1. presignedURL 업로드 api 호출
2. 리턴된 URL을 put 메서드와 MultipartFile로 업로드
3. presignedURL에서 쿼리파라미터 제거한 url과 함께 기존 api에 담아서 전달