### PR TITLE
Feat: 반려동물 전체 조회, id별 조회, 삭제 API 추가

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/repository/MemberQueryRepository.java
@@ -2,7 +2,6 @@ package org.retriever.server.dailypet.domain.member.repository;
 
 import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
-import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -19,12 +18,6 @@ public class MemberQueryRepository {
                         " join fetch f.family" +
                         " where f.member.id = :memberId", FamilyMember.class)
                 .setParameter("memberId", memberId)
-                .getResultList();
-    }
-
-    public List<Pet> findPetByFamilyId(Long familyId) {
-        return entityManager.createQuery("select p from Pet p where p.family.familyId = :familyId", Pet.class)
-                .setParameter("familyId", familyId)
                 .getResultList();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -18,6 +18,7 @@ import org.retriever.server.dailypet.domain.member.repository.MemberQueryReposit
 import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.pet.exception.PetNotFoundException;
+import org.retriever.server.dailypet.domain.pet.repository.PetQueryRepository;
 import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
 import org.retriever.server.dailypet.global.config.jwt.JwtTokenProvider;
 import org.retriever.server.dailypet.global.utils.LocalDateTimeUtils;
@@ -38,7 +39,7 @@ public class MemberService {
     private final FamilyRepository familyRepository;
     private final PetRepository petRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final S3FileUploader s3FileUploader;
+    private final PetQueryRepository petQueryRepository;
     private final MemberQueryRepository memberQueryRepository;
     private final SecurityUtil securityUtil;
 
@@ -52,7 +53,7 @@ public class MemberService {
         if (!familyList.isEmpty()) {
             family = familyList.get(0).getFamily();
         }
-        List<Pet> petList = memberQueryRepository.findPetByFamilyId(family.getFamilyId());
+        List<Pet> petList = petQueryRepository.findPetsByFamilyId(family.getFamilyId());
 
         if (!member.getProviderType().equals(dto.getProviderType())) {
             throw new DifferentProviderTypeException();
@@ -113,7 +114,7 @@ public class MemberService {
     }
 
     public CheckPetResponse checkPet(Long familyId) {
-        List<Pet> petByFamilyId = memberQueryRepository.findPetByFamilyId(familyId);
+        List<Pet> petByFamilyId = petQueryRepository.findPetsByFamilyId(familyId);
         if (petByFamilyId.isEmpty()) {
             throw new PetNotFoundException();
         }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
 import org.retriever.server.dailypet.domain.pet.dto.response.GetPetKindListResponse;
+import org.retriever.server.dailypet.domain.pet.dto.response.GetPetsResponse;
 import org.retriever.server.dailypet.domain.pet.dto.response.RegisterPetResponse;
 import org.retriever.server.dailypet.domain.pet.enums.PetType;
 import org.retriever.server.dailypet.domain.pet.service.PetService;
@@ -63,5 +64,17 @@ public class PetController {
     @PostMapping("/families/{familyId}/pet")
     public ResponseEntity<RegisterPetResponse> registerPet(@RequestBody @Valid RegisterPetRequest dto, @PathVariable Long familyId) throws IOException {
         return ResponseEntity.ok(petService.registerPet(dto, familyId));
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "반려 동물 전체 조회", description = "가족에서 관리하는 반려동물 정보를 전체 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "반려동물 조회 완료"),
+            @ApiResponse(responseCode = "400", description = "반려동물 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/families/{familyId}/pets")
+    public ResponseEntity<GetPetsResponse> getPetsByFamilyId(@PathVariable Long familyId) throws IOException {
+        return ResponseEntity.ok(petService.getPetsByFamilyId(familyId));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -10,6 +10,7 @@ import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
 import org.retriever.server.dailypet.domain.pet.dto.response.GetPetKindListResponse;
 import org.retriever.server.dailypet.domain.pet.dto.response.GetPetsResponse;
+import org.retriever.server.dailypet.domain.pet.dto.response.PetInfoDetail;
 import org.retriever.server.dailypet.domain.pet.dto.response.RegisterPetResponse;
 import org.retriever.server.dailypet.domain.pet.enums.PetType;
 import org.retriever.server.dailypet.domain.pet.service.PetService;
@@ -76,5 +77,17 @@ public class PetController {
     @GetMapping("/families/{familyId}/pets")
     public ResponseEntity<GetPetsResponse> getPetsByFamilyId(@PathVariable Long familyId) throws IOException {
         return ResponseEntity.ok(petService.getPetsByFamilyId(familyId));
+    }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "반려 동물 단일 조회", description = "가족에서 관리하는 반려동물을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "반려동물 조회 완료"),
+            @ApiResponse(responseCode = "400", description = "반려동물 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/families/{familyId}/pets/{petId}")
+    public ResponseEntity<PetInfoDetail> getPetInfo(@PathVariable Long petId) throws IOException {
+        return ResponseEntity.ok(petService.getPetInfo(petId));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/controller/PetController.java
@@ -90,4 +90,17 @@ public class PetController {
     public ResponseEntity<PetInfoDetail> getPetInfo(@PathVariable Long petId) throws IOException {
         return ResponseEntity.ok(petService.getPetInfo(petId));
     }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "반려 동물 삭제", description = "가족에서 관리하는 반려동물을 삭제한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "반려동물 삭제 완료"),
+            @ApiResponse(responseCode = "400", description = "반려동물 삭제 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @DeleteMapping("/families/{familyId}/pets/{petId}")
+    public ResponseEntity<Void> deletePetInfo(@PathVariable Long petId) throws IOException {
+        petService.deletePetInfo(petId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/GetPetsResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/GetPetsResponse.java
@@ -1,0 +1,21 @@
+package org.retriever.server.dailypet.domain.pet.dto.response;
+
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class GetPetsResponse {
+
+    List<PetInfoDetail> petInfoDetailList = new ArrayList<>();
+
+    public static GetPetsResponse from(List<PetInfoDetail> petInfoDetailList) {
+        return GetPetsResponse.builder()
+                .petInfoDetailList(petInfoDetailList)
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/PetInfoDetail.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/PetInfoDetail.java
@@ -1,0 +1,59 @@
+package org.retriever.server.dailypet.domain.pet.dto.response;
+
+import lombok.*;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.retriever.server.dailypet.domain.pet.enums.Gender;
+
+import java.time.LocalDate;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PetInfoDetail {
+
+    private Long petId;
+
+    private String petName;
+
+    private String profileImageUrl;
+
+    private LocalDate birthDate;
+
+    private Double weight;
+
+    private String registerNumber;
+
+    private Boolean isNeutered;
+
+    private Gender gender;
+
+    private String petKind;
+
+    // builder는 전체 생성자가 필요하고, 생성자가 없을 경우 내부적으로 전체 생성자(package level)로 만들어서 사용하는데, 생성자를 만든 경우 allargsConstructor를 생성하지 않기 때문에 에러가 난다.
+    public PetInfoDetail(Pet pet) {
+        this.petId = pet.getPetId();
+        this.petName = pet.getPetName();
+        this.profileImageUrl = pet.getProfileImageUrl();
+        this.birthDate = pet.getBirthDate();
+        this.weight = pet.getWeight();
+        this.registerNumber = pet.getRegisterNumber();
+        this.isNeutered = pet.getIsNeutered();
+        this.gender = pet.getGender();
+        this.petKind = pet.getPetKind().getPetKindName();
+    }
+
+    public static PetInfoDetail from(Pet pet) {
+        return PetInfoDetail.builder()
+                .petId(pet.getPetId())
+                .petName(pet.getPetName())
+                .profileImageUrl(pet.getProfileImageUrl())
+                .birthDate(pet.getBirthDate())
+                .weight(pet.getWeight())
+                .registerNumber(pet.getRegisterNumber())
+                .isNeutered(pet.getIsNeutered())
+                .gender(pet.getGender())
+                .petKind(pet.getPetKind().getPetKindName())
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetQueryRepository.java
@@ -22,4 +22,14 @@ public class PetQueryRepository {
                 .setParameter("familyId", familyId)
                 .getResultList();
     }
+
+    public Pet findPetByPetId(Long petId) {
+        return entityManager.createQuery(
+                        "select p from Pet p" +
+                                " join fetch p.petKind pk" +
+                                " where p.petId = :petId"
+                        , Pet.class)
+                .setParameter("petId", petId)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetQueryRepository.java
@@ -1,0 +1,23 @@
+package org.retriever.server.dailypet.domain.pet.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.pet.entity.Pet;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PetQueryRepository {
+
+    private final EntityManager entityManager;
+
+    public List<Pet> findPetsByFamilyId(Long familyId) {
+        return entityManager.createQuery(
+                        "select p from Pet p where p.family.familyId = :familyId"
+                        , Pet.class)
+                .setParameter("familyId", familyId)
+                .getResultList();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/repository/PetQueryRepository.java
@@ -15,7 +15,9 @@ public class PetQueryRepository {
 
     public List<Pet> findPetsByFamilyId(Long familyId) {
         return entityManager.createQuery(
-                        "select p from Pet p where p.family.familyId = :familyId"
+                        "select p from Pet p" +
+                                " join fetch p.petKind pk" +
+                                " where p.family.familyId = :familyId"
                         , Pet.class)
                 .setParameter("familyId", familyId)
                 .getResultList();

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
@@ -84,4 +84,8 @@ public class PetService {
                 .collect(Collectors.toList())
         );
     }
+
+    public PetInfoDetail getPetInfo(Long petId) {
+        return PetInfoDetail.from(petQueryRepository.findPetByPetId(petId));
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
@@ -7,18 +7,15 @@ import org.retriever.server.dailypet.domain.family.repository.FamilyRepository;
 import org.retriever.server.dailypet.domain.member.entity.Member;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.dto.request.ValidatePetNameInFamilyRequest;
-import org.retriever.server.dailypet.domain.pet.dto.response.GetPetKindListResponse;
-import org.retriever.server.dailypet.domain.pet.dto.response.PetKindPair;
-import org.retriever.server.dailypet.domain.pet.dto.response.RegisterPetResponse;
+import org.retriever.server.dailypet.domain.pet.dto.response.*;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.pet.entity.PetKind;
 import org.retriever.server.dailypet.domain.pet.enums.PetType;
 import org.retriever.server.dailypet.domain.pet.exception.DuplicatePetNameInFamilyException;
 import org.retriever.server.dailypet.domain.pet.exception.PetTypeNotFoundException;
 import org.retriever.server.dailypet.domain.pet.repository.PetKindRepository;
+import org.retriever.server.dailypet.domain.pet.repository.PetQueryRepository;
 import org.retriever.server.dailypet.domain.pet.repository.PetRepository;
-import org.retriever.server.dailypet.domain.petcare.repository.CareLogQueryRepository;
-import org.retriever.server.dailypet.global.utils.s3.S3FileUploader;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,9 +32,8 @@ public class PetService {
     private final FamilyRepository familyRepository;
     private final PetKindRepository petKindRepository;
     private final PetRepository petRepository;
-    private final CareLogQueryRepository careLogRepository;
-    private final S3FileUploader s3FileUploader;
     private final SecurityUtil securityUtil;
+    private final PetQueryRepository petQueryRepository;
 
     // TODO : 멤버 정보를 이용해서 속한 가족 정보를 바로 참조하는 쿼리 작성 (현재는 familyMember를 거쳐야함)
     public void validatePetNameInFamily(ValidatePetNameInFamilyRequest dto, Long familyId) {
@@ -77,5 +73,15 @@ public class PetService {
         petRepository.save(newPet);
 
         return RegisterPetResponse.of(member, family);
+    }
+
+    public GetPetsResponse getPetsByFamilyId(Long familyId) {
+
+        List<Pet> petList = petQueryRepository.findPetsByFamilyId(familyId);
+
+        return GetPetsResponse.from(petList.stream()
+                .map(PetInfoDetail::new)
+                .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/service/PetService.java
@@ -88,4 +88,9 @@ public class PetService {
     public PetInfoDetail getPetInfo(Long petId) {
         return PetInfoDetail.from(petQueryRepository.findPetByPetId(petId));
     }
+
+    @Transactional
+    public void deletePetInfo(Long petId) {
+        petRepository.deleteById(petId);
+    }
 }

--- a/src/main/java/org/retriever/server/dailypet/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/retriever/server/dailypet/global/config/security/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .accessDeniedHandler(jwtAccessDeniedHandler)
                 .and()
                     .authorizeRequests()
+                    .antMatchers(HttpMethod.DELETE, "/api/v1/families/{familyId}/pets/{petId}").hasAuthority("FAMILY_LEADER")
                     .antMatchers(HttpMethod.POST, "/api/v1/auth/login",
                             "/api/v1/validation/nickname", "/api/v1/auth/sign-up").permitAll()
                     .antMatchers(HttpMethod.GET, "/api/v1/test").permitAll()

--- a/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/member/service/MemberServiceTest.java
@@ -24,6 +24,7 @@ import org.retriever.server.dailypet.domain.member.exception.MemberNotFoundExcep
 import org.retriever.server.dailypet.domain.member.repository.MemberQueryRepository;
 import org.retriever.server.dailypet.domain.member.repository.MemberRepository;
 import org.retriever.server.dailypet.domain.pet.exception.PetNotFoundException;
+import org.retriever.server.dailypet.domain.pet.repository.PetQueryRepository;
 import org.retriever.server.dailypet.global.config.jwt.JwtTokenProvider;
 import org.retriever.server.dailypet.global.utils.s3.S3FileUploader;
 import org.retriever.server.dailypet.global.utils.security.SecurityUtil;
@@ -51,6 +52,8 @@ class MemberServiceTest {
     SecurityUtil securityUtil;
     @Mock
     FamilyRepository familyRepository;
+    @Mock
+    PetQueryRepository petQueryRepository;
 
     @InjectMocks
     MemberService memberService;
@@ -191,7 +194,7 @@ class MemberServiceTest {
     void check_pet_fail_and_throw_exception() {
 
         // given
-        given(memberQueryRepository.findPetByFamilyId(any())).willReturn(new ArrayList<>());
+        given(petQueryRepository.findPetsByFamilyId(any())).willReturn(new ArrayList<>());
 
         // when, then
         assertThrows(PetNotFoundException.class, () -> memberService.checkPet(any()));


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 전체 조회, ID별 조회, 삭제 API 추가
- 삭제 API는 그룹 리더만 삭제할 수 있도록 spring security에 hasAuthority 추가
- hasRole로 하면 자동으로 ROLE_이 prefix로 붙어서 DB에 저장되는 String이 ROLE_~로 저장되어야 함.

## Test Checklist

- [ ] 

## To Client

- 반려동물 전체 조회, id별 조회, 삭제 API 추가
- 수정은 아직 결정된 게 아닌 거 같아서 나중에 추가합니다!
