### PR TITLE
Fix: 챙겨주기 취소 API 오류 수정, Pet 도메인 petType 필드 추가, response 수정

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/controller/FamilyController.java
@@ -11,6 +11,7 @@ import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyReques
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
+import org.retriever.server.dailypet.domain.family.dto.response.EnterFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.service.FamilyService;
 import org.springframework.http.ResponseEntity;
@@ -97,9 +98,8 @@ public class FamilyController {
             @ApiResponse(responseCode = "500", description = "내부 서버 에러")
     })
     @PostMapping("/families/{familyId}")
-    public ResponseEntity<Void> enterFamily(
+    public ResponseEntity<EnterFamilyResponse> enterFamily(
             @PathVariable Long familyId, @RequestBody @Valid EnterFamilyRequest dto) {
-        familyService.enterFamily(familyId, dto);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(familyService.enterFamily(familyId, dto));
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/EnterFamilyResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/dto/response/EnterFamilyResponse.java
@@ -1,0 +1,45 @@
+package org.retriever.server.dailypet.domain.family.dto.response;
+
+import lombok.*;
+import org.retriever.server.dailypet.domain.family.entity.Family;
+import org.retriever.server.dailypet.domain.family.enums.GroupType;
+import org.retriever.server.dailypet.domain.member.entity.Member;
+import org.retriever.server.dailypet.domain.pet.dto.response.PetInfoResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class EnterFamilyResponse {
+
+    private Long familyId;
+
+    private String familyName;
+
+    private String nickName;
+
+    private String invitationCode;
+
+    private GroupType groupType;
+
+    private String profileImageUrl;
+
+    private List<PetInfoResponse> petList;
+
+    public static EnterFamilyResponse of(Member member, Family family) {
+        return EnterFamilyResponse.builder()
+                .familyId(family.getFamilyId())
+                .familyName(family.getFamilyName())
+                .nickName(member.getNickName())
+                .groupType(family.getGroupType())
+                .profileImageUrl(member.getProfileImageUrl())
+                .petList(family.getPetList().stream()
+                        .map(PetInfoResponse::new)
+                        .collect(Collectors.toList()))
+                .invitationCode(family.getInvitationCode())
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/family/service/FamilyService.java
@@ -6,6 +6,7 @@ import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyReques
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
+import org.retriever.server.dailypet.domain.family.dto.response.EnterFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
 import org.retriever.server.dailypet.domain.family.entity.FamilyMember;
@@ -96,7 +97,7 @@ public class FamilyService {
     }
 
     @Transactional
-    public void enterFamily(Long familyId, EnterFamilyRequest dto) {
+    public EnterFamilyResponse enterFamily(Long familyId, EnterFamilyRequest dto) {
         Member member = securityUtil.getMemberByUserDetails();
 
         Family family = familyRepository.findById(familyId).orElseThrow(FamilyNotFoundException::new);
@@ -106,5 +107,7 @@ public class FamilyService {
         FamilyMember familyMember = FamilyMember.createFamilyMember(member, family);
 
         family.insertNewMember(familyMember);
+
+        return EnterFamilyResponse.of(member, family);
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/PetInfoDetail.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/dto/response/PetInfoDetail.java
@@ -3,6 +3,7 @@ package org.retriever.server.dailypet.domain.pet.dto.response;
 import lombok.*;
 import org.retriever.server.dailypet.domain.pet.entity.Pet;
 import org.retriever.server.dailypet.domain.pet.enums.Gender;
+import org.retriever.server.dailypet.domain.pet.enums.PetType;
 
 import java.time.LocalDate;
 
@@ -30,6 +31,8 @@ public class PetInfoDetail {
 
     private String petKind;
 
+    private PetType petType;
+
     // builder는 전체 생성자가 필요하고, 생성자가 없을 경우 내부적으로 전체 생성자(package level)로 만들어서 사용하는데, 생성자를 만든 경우 allargsConstructor를 생성하지 않기 때문에 에러가 난다.
     public PetInfoDetail(Pet pet) {
         this.petId = pet.getPetId();
@@ -41,6 +44,7 @@ public class PetInfoDetail {
         this.isNeutered = pet.getIsNeutered();
         this.gender = pet.getGender();
         this.petKind = pet.getPetKind().getPetKindName();
+        this.petType = pet.getPetType();
     }
 
     public static PetInfoDetail from(Pet pet) {
@@ -54,6 +58,7 @@ public class PetInfoDetail {
                 .isNeutered(pet.getIsNeutered())
                 .gender(pet.getGender())
                 .petKind(pet.getPetKind().getPetKindName())
+                .petType(pet.getPetType())
                 .build();
     }
 }

--- a/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/pet/entity/Pet.java
@@ -8,6 +8,7 @@ import org.retriever.server.dailypet.domain.model.BaseTimeEntity;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.enums.Gender;
 import org.retriever.server.dailypet.domain.pet.enums.PetStatus;
+import org.retriever.server.dailypet.domain.pet.enums.PetType;
 import org.retriever.server.dailypet.domain.petcare.entity.CareLog;
 import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 
@@ -50,6 +51,9 @@ public class Pet extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PetStatus petStatus;
 
+    @Enumerated(EnumType.STRING)
+    private PetType petType;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petKindId", nullable = false)
     private PetKind petKind;
@@ -76,6 +80,7 @@ public class Pet extends BaseTimeEntity {
                 .isNeutered(dto.getIsNeutered())
                 .gender(dto.getGender())
                 .petStatus(PetStatus.ACTIVE)
+                .petType(dto.getPetType())
                 .build();
     }
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CancelPetCareResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CancelPetCareResponse.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.petcare.dto.response;
 
 import lombok.*;
 import org.retriever.server.dailypet.domain.pet.dto.response.CareLogHistory;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,15 +13,20 @@ import java.util.List;
 @Getter
 public class CancelPetCareResponse {
 
-    private Long petCareId;
+    private Long careId;
+
+    private String careName;
+
+    private int totalCareCount;
 
     private int currentCount;
 
     private List<CareLogHistory> checkList = new ArrayList<>();
 
-    public static CancelPetCareResponse of(Long petCareId, int afterCount, List<CareLogHistory> logHistoryList) {
+    public static CancelPetCareResponse of(PetCare petCare, int afterCount, List<CareLogHistory> logHistoryList) {
         return CancelPetCareResponse.builder()
-                .petCareId(petCareId)
+                .careId(petCare.getPetCareId())
+                .careName(petCare.getCareName())
                 .currentCount(afterCount)
                 .checkList(logHistoryList)
                 .build();

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CheckPetCareResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/dto/response/CheckPetCareResponse.java
@@ -2,6 +2,7 @@ package org.retriever.server.dailypet.domain.petcare.dto.response;
 
 import lombok.*;
 import org.retriever.server.dailypet.domain.pet.dto.response.CareLogHistory;
+import org.retriever.server.dailypet.domain.petcare.entity.PetCare;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,15 +13,20 @@ import java.util.List;
 @Getter
 public class CheckPetCareResponse {
 
-    private Long petCareId;
+    private Long careId;
+
+    private String careName;
+
+    private int totalCareCount;
 
     private int currentCount;
 
     private List<CareLogHistory> checkList = new ArrayList<>();
 
-    public static CheckPetCareResponse of(Long petCareId, int afterCount, List<CareLogHistory> logHistoryList) {
+    public static CheckPetCareResponse of(PetCare petCare, int afterCount, List<CareLogHistory> logHistoryList) {
         return CheckPetCareResponse.builder()
-                .petCareId(petCareId)
+                .careId(petCare.getPetCareId())
+                .careName(petCare.getCareName())
                 .currentCount(afterCount)
                 .checkList(logHistoryList)
                 .build();

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/entity/CareLog.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "is_deleted = 'FALSE'")
+@Where(clause = "is_deleted = 'FALSE' and care_log_status = 'CHECK'")
 @SQLDelete(sql = "UPDATE care_log SET is_deleted = 'TRUE' WHERE care_log_id = ?")
 public class CareLog extends BaseTimeEntity {
 

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/repository/CareLogQueryRepository.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/repository/CareLogQueryRepository.java
@@ -35,8 +35,10 @@ public class CareLogQueryRepository {
                         " ", CareLog.class)
                 .setParameter("memberId", memberId)
                 .setParameter("petCareId", petCareId)
-                .setMaxResults(1)
-                .getSingleResult();
+                .getResultList()
+                .stream()
+                .findFirst()
+                .orElse(null);
     }
 
     // 오늘 해당 챙겨주기 항목에 대한 횟수 조회 쿼리

--- a/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/petcare/service/PetCareService.java
@@ -115,7 +115,7 @@ public class PetCareService {
 
         careLogRepository.save(CareLog.of(member, pet, petCare, CareLogStatus.CHECK));
 
-        return CheckPetCareResponse.of(petCareId, afterCount, getCareLogHistory(petCareId));
+        return CheckPetCareResponse.of(petCare, afterCount, getCareLogHistory(petCareId));
     }
 
     /**
@@ -136,7 +136,7 @@ public class PetCareService {
         int afterCount = petCare.cancelCareCheckButton(currentCount);
         careLog.cancel();
 
-        return new CancelPetCareResponse(petCareId, afterCount, getCareLogHistory(petCareId));
+        return CancelPetCareResponse.of(petCare, afterCount, getCareLogHistory(petCareId));
     }
 
     private List<CareLogHistory> getCareLogHistory(Long petCareId) {

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/FamilyFactory.java
@@ -23,6 +23,7 @@ public class FamilyFactory {
 
     public static Family createTestFamily() {
         return Family.builder()
+                .familyId(1L)
                 .familyName("testFamily")
                 .familyStatus(FamilyStatus.ACTIVE)
                 .invitationCode("1234567890")

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetCareFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetCareFactory.java
@@ -38,4 +38,14 @@ public class PetCareFactory {
                 .petCareAlarmList(List.of(petCareAlarm))
                 .build();
     }
+
+    public static PetCare createTestPetCareForThread(Long id, int cnt, Pet pet) {
+        return PetCare.builder()
+                .petCareId(id)
+                .careName("testCare")
+                .totalCountPerDay(cnt)
+                .pet(pet)
+                .isDeleted(IsDeleted.FALSE)
+                .build();
+    }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/common/factory/PetFactory.java
@@ -40,6 +40,7 @@ public class PetFactory {
                 .weight(5.8)
                 .petKindId(1L)
                 .profileImageUrl("testProfile")
+                .petType(PetType.DOG)
                 .build();
     }
 

--- a/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/family/service/FamilyServiceTest.java
@@ -13,6 +13,7 @@ import org.retriever.server.dailypet.domain.family.dto.request.EnterFamilyReques
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.request.ValidateFamilyRoleNameRequest;
 import org.retriever.server.dailypet.domain.family.dto.response.CreateFamilyResponse;
+import org.retriever.server.dailypet.domain.family.dto.response.EnterFamilyResponse;
 import org.retriever.server.dailypet.domain.family.dto.response.FamilyMemberInfo;
 import org.retriever.server.dailypet.domain.family.dto.response.FindFamilyWithInvitationCodeResponse;
 import org.retriever.server.dailypet.domain.family.entity.Family;
@@ -157,10 +158,16 @@ class FamilyServiceTest {
         when(securityUtil.getMemberByUserDetails()).thenReturn(member);
 
         // when
-        familyService.enterFamily(family.getFamilyId(), request);
+        EnterFamilyResponse enterFamilyResponse = familyService.enterFamily(family.getFamilyId(), request);
 
         // then
         assertThat(member.getFamilyRoleName()).isEqualTo(request.getFamilyRoleName());
         assertThat(family.getFamilyMemberList().size()).isEqualTo(size+1);
+        assertThat(enterFamilyResponse.getFamilyId()).isEqualTo(family.getFamilyId());
+        assertThat(enterFamilyResponse.getFamilyName()).isEqualTo(family.getFamilyName());
+        assertThat(enterFamilyResponse.getGroupType()).isEqualTo(family.getGroupType());
+        assertThat(enterFamilyResponse.getInvitationCode()).isEqualTo(family.getInvitationCode());
+        assertThat(enterFamilyResponse.getProfileImageUrl()).isEqualTo(member.getProfileImageUrl());
+        assertThat(enterFamilyResponse.getProfileImageUrl()).isEqualTo(member.getProfileImageUrl());
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/pet/entity/PetTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/pet/entity/PetTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.retriever.server.dailypet.domain.common.factory.PetFactory;
 import org.retriever.server.dailypet.domain.pet.dto.request.RegisterPetRequest;
 import org.retriever.server.dailypet.domain.pet.enums.PetStatus;
+import org.retriever.server.dailypet.domain.pet.enums.PetType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,5 +30,6 @@ class PetTest {
         assertThat(pet.getWeight()).isEqualTo(request.getWeight());
         assertThat(pet.getIsNeutered()).isEqualTo(request.getIsNeutered());
         assertThat(pet.getPetStatus()).isEqualTo(PetStatus.ACTIVE);
+        assertThat(pet.getPetType()).isEqualTo(PetType.DOG);
     }
 }

--- a/src/test/java/org/retriever/server/dailypet/domain/petcare/service/PetCareServiceTest.java
+++ b/src/test/java/org/retriever/server/dailypet/domain/petcare/service/PetCareServiceTest.java
@@ -95,7 +95,7 @@ class PetCareServiceTest {
                 () -> verify(careLogQueryRepository, times(1)).findTodayCountByCareId(any()),
                 () -> assertEquals(checkPetCareResponse.getCurrentCount(), beforeCount+1),
                 () -> assertEquals(checkPetCareResponse.getCheckList().get(0).getFamilyRoleName(), testMember.getFamilyRoleName()),
-                () -> assertEquals(checkPetCareResponse.getPetCareId(), testPetCare.getPetCareId())
+                () -> assertEquals(checkPetCareResponse.getCareId(), testPetCare.getPetCareId())
         );
     }
 

--- a/src/test/java/org/retriever/server/dailypet/integration/IntegrationTest.java
+++ b/src/test/java/org/retriever/server/dailypet/integration/IntegrationTest.java
@@ -1,0 +1,9 @@
+package org.retriever.server.dailypet.integration;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public abstract class IntegrationTest {
+}


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 챙겨주기 취소가 정상적으로 동작하지 않는 오류 수정 - careLog가 CHECK인 것만 조회하도록 수정
- Pet 도메인에 petType 필드 추가
- 가족 입장 시 response 추가
- 챙겨주기 체크, 취소 시 response 수정

## Test Checklist

- [ ] 

## To Client

- 요구사항 수정 완료
- 로그인, 펫 등록 시 petList삭제만 보류
- 챙겨주기 메인 파트 끝인 것 같습니다.
