### PR TITLE
Bugfix: 퍼센트 계산 시 divideByZero

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/report/service/ReportService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/report/service/ReportService.java
@@ -77,6 +77,9 @@ public class ReportService {
 
     private float getPercentByMemberId(List<CareLog> careLogList, Long memberId) {
         int totalCount = careLogList.size();
+        if (totalCount == 0) {
+            return 0;
+        }
         int myCount = getCountByMemberId(careLogList, memberId);
         return (float) myCount / totalCount * 100;
     }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 퍼센트 계산 시 totalCount가 0일 경우 나누지 않고 0 리턴

## Test Checklist

- [ ] 

## To Client

- 
