### PR TITLE
Feat: presignedUrl get API 추가

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/s3/S3Controller.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/s3/S3Controller.java
@@ -1,0 +1,37 @@
+package org.retriever.server.dailypet.domain.s3;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.retriever.server.dailypet.domain.s3.dto.PresignedUrlResponse;
+import org.retriever.server.dailypet.global.utils.s3.S3FileUploader;
+import org.retriever.server.dailypet.global.utils.s3.S3Path;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Image Upload API")
+public class S3Controller {
+
+    private final S3FileUploader s3FileUploader;
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "이미지 signedURL 반환 API", description = "파일의 이름 (dog.jpeg)과 종류에 맞는 enum type(MEMBER, PET, DIARY)을 넘겨서 signedURL을 얻는다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정상 요청 완료"),
+            @ApiResponse(responseCode = "400", description = "요청 실패"),
+            @ApiResponse(responseCode = "500", description = "내부 서버 에러")
+    })
+    @GetMapping("/PresignedUrl/{S3Path}/{fileName}")
+    public ResponseEntity<PresignedUrlResponse> getPresignedUrl(@PathVariable S3Path S3Path, @PathVariable String fileName) {
+        return ResponseEntity.ok(s3FileUploader.getPreSignedUrl(S3Path, fileName));
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/domain/s3/dto/PresignedUrlResponse.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/s3/dto/PresignedUrlResponse.java
@@ -1,0 +1,24 @@
+package org.retriever.server.dailypet.domain.s3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class PresignedUrlResponse {
+
+    private String presignedUrl;
+
+    private String originalUrl;
+
+    public static PresignedUrlResponse from(String presignedUrl) {
+        return PresignedUrlResponse.builder()
+                .presignedUrl(presignedUrl)
+                .originalUrl(presignedUrl.substring(0, presignedUrl.lastIndexOf("?")))
+                .build();
+    }
+}

--- a/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3FileUploader.java
+++ b/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3FileUploader.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.retriever.server.dailypet.domain.s3.dto.PresignedUrlResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -23,13 +24,11 @@ public class S3FileUploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String getPreSignedUrl(String dirName, String fileName) {
-        if (!dirName.equals("")) {
-            fileName = dirName + "/" + fileName;
-        }
+    public PresignedUrlResponse getPreSignedUrl(S3Path s3Path, String fileName) {
+        fileName = s3Path.getFilePath() + fileName;
         GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(fileName);
         URL url = amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
-        return url.toString();
+        return PresignedUrlResponse.from(url.toString());
     }
 
     private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String fileName) {

--- a/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3Path.java
+++ b/src/main/java/org/retriever/server/dailypet/global/utils/s3/S3Path.java
@@ -1,0 +1,16 @@
+package org.retriever.server.dailypet.global.utils.s3;
+
+import lombok.Getter;
+
+@Getter
+public enum S3Path {
+    MEMBER("image/member/"),
+    DIARY("image/diary/"),
+    PET("image/pet/");
+
+    private final String filePath;
+
+    S3Path(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ cloud:
       secret-key: ${AWS_SECRET_KEY}
       instance-profile: true
     s3:
-      bucket: dailypet-test-bucket
+      bucket: ${AWS_BUCKET_NAME}
 
 decorator:
   datasource:


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : https://github.com/SWM-Retriever/Server/issues/41
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 이미지 업로드 요청 api 추가

## Test Checklist

- [ ] 

## To Client

- 해당 API에 MEMBER, DIARY, PET과 사진 이름(확장자까지)를 입력하고나서 api를 요청하면 presignedUrl과 이미지가 저장된 url을 반환합니다. 업로드가 정상적으로 200ok가 뜨면 저장된 url을 이용하면 됩니다. 이후 다른 요청에 해당 url 보내면 됩니다~
