### PR TITLE
Fix: 회원 탈퇴 로직 수정 - 그룹장만 그룹 삭제

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/entity/Member.java
@@ -154,4 +154,8 @@ public class Member extends BaseTimeEntity {
     public void createDiary(Diary diary) {
         this.diaryList.add(diary);
     }
+
+    public boolean isFamilyLeader() {
+        return this.roleType == RoleType.FAMILY_LEADER;
+    }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 회원 탈퇴 시 그룹까지 삭제되는 문제 수정
- 그룹장인 경우에만 그룹 삭제가 진행되고 일반 유저는 회원 탈퇴만 진행

## Test Checklist

- [ ] 

## To Client

- 
