### PR TITLE
Fix: 회원 탈퇴 시 그룹 구성원 count 셀때 제외되는 오류 수정

### DIFF
--- a/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
+++ b/src/main/java/org/retriever/server/dailypet/domain/member/service/MemberService.java
@@ -122,28 +122,26 @@ public class MemberService {
     public void deleteMember() {
         Member member = securityUtil.getMemberByUserDetails();
         Family family = getFamily(member);
+        int groupMembersCount = getFamilyMembers(family);
 
-        if (canDeleteMember(member, family)) {
+        if (canDeleteMember(member, groupMembersCount)) {
             memberRepository.delete(member);
         }
 
-        if (canDeleteGroup(member, family)) {
+        if (canDeleteGroup(member, groupMembersCount)) {
             familyRepository.delete(family);
         }
     }
 
-    private Boolean canDeleteMember(Member member, Family family) {
-        if (member.isFamilyLeader() && getFamilyMembers(family).size() > 1) {
+    private Boolean canDeleteMember(Member member, int groupMembersCount) {
+        if (member.isFamilyLeader() && groupMembersCount > 1) {
             throw new CannotDeleteMemberException();
         }
         return true;
     }
 
-    private Boolean canDeleteGroup(Member member, Family family) {
-        if (family == null) {
-            return false;
-        }
-        return member.isFamilyLeader() && getFamilyMembers(family).size() == 1;
+    private Boolean canDeleteGroup(Member member, int groupMemberCount) {
+        return member.isFamilyLeader() && groupMemberCount == 1;
     }
 
     private Family getFamily(Member member) {
@@ -154,7 +152,9 @@ public class MemberService {
         return null;
     }
 
-    private List<FamilyMember> getFamilyMembers(Family family) {
-        return familyQueryRepository.findMembersByFamilyId(family.getFamilyId());
+    private int getFamilyMembers(Family family) {
+        if(family == null)
+            return 0;
+        return familyQueryRepository.findMembersByFamilyId(family.getFamilyId()).size();
     }
 }


### PR DESCRIPTION
# What is this PR?

- **관련 이슈** : N/A
- **JIRA 백로그** : N/A
- **관련 문서** : N/A

## Changes 

- 회원 탈퇴가 진행되면 그룹 삭제 조건에서 그룹 구성원 수를 셀 때 제외되서 로직이 정상적으로 수행되지 않음

## Test Checklist

- [ ] 

## To Client

- 
